### PR TITLE
Security scan needs to run on master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,12 +54,6 @@ jobs:
         docker tag api:latest registry.digitalocean.com/foreign-language-reader-api/api:latest
         docker push registry.digitalocean.com/foreign-language-reader-api/api:latest
 
-    - name: Upload security scan report
-      if: ${{ always() }}
-      uses: github/codeql-action/upload-sarif@v1
-      with:
-        sarif_file: ${{ steps.scan.outputs.sarif }}
-
   deploy:
     name: Deploy API
     runs-on: ubuntu-latest

--- a/.github/workflows/master_baseline.yml
+++ b/.github/workflows/master_baseline.yml
@@ -34,3 +34,27 @@ jobs:
       with:
         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
         coverage-reports: api/target/scala-2.12/coverage-report/cobertura.xml, content/target/scala-2.12/coverage-report/cobertura.xml, domain/target/scala-2.12/coverage-report/cobertura.xml, jobs/target/scala-2.12/coverage-report/cobertura.xml
+
+
+  # This needs a master reference, not a closed pull request reference. Keep it here.
+  security:
+    runs-on: ubuntu-latest
+    name: Security scan
+    steps:
+    - uses: actions/checkout@v2.3.4
+
+    - name: Build container
+      run: docker build . -t api
+
+    - name: Container security scan
+      id: scan
+      uses: anchore/scan-action@v2
+      with:
+        image: "api:latest"
+        acs-report-enable: true
+
+    - name: Upload scan report
+      if: ${{ always() }}
+      uses: github/codeql-action/upload-sarif@v1
+      with:
+        sarif_file: ${{ steps.scan.outputs.sarif }} 


### PR DESCRIPTION
- One run blocks deployment if security vulnerabilities are found.
- Another run sets a baseline for security by scanning master.
- These cannot be separate jobs.