### PR TITLE
Split docker images

### DIFF
--- a/.github/workflows/api_test.yml
+++ b/.github/workflows/api_test.yml
@@ -8,9 +8,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.3.4
-
-    - name: Hadolint Action
-      uses: brpaz/hadolint-action@v1.3.1
+    
+    - uses: brpaz/hadolint-action@v1.3.1
+      name: Lint base image
+      with:
+        dockerfile: Dockerfile_base
+    
+    - uses: brpaz/hadolint-action@v1.3.1
+      name: Lint builder image
+      with:
+        dockerfile: Dockerfile_builder
+    
+    - uses: brpaz/hadolint-action@v1.3.1
+      name: Lint production image
+      with:
+        dockerfile: Dockerfile
 
     - name: Build container
       run: docker build . -t api

--- a/.github/workflows/api_test.yml
+++ b/.github/workflows/api_test.yml
@@ -29,6 +29,12 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
+    
+    # Do this in case they have changed
+    - name: Build dependencies image
+      run: |
+        docker pull lkjaero/foreign-language-reader-api:builder
+        docker build . -f Dockerfile_builder -t lkjaero/foreign-language-reader-api:builder
 
     - name: Build container
       run: docker build . -t api

--- a/.github/workflows/api_test.yml
+++ b/.github/workflows/api_test.yml
@@ -31,6 +31,8 @@ jobs:
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     
     # Do this in case they have changed
+    # Pulling is there for caching, in case nothing has changed
+    # Remember not to push
     - name: Build dependencies image
       run: |
         docker pull lkjaero/foreign-language-reader-api:builder

--- a/.github/workflows/api_test.yml
+++ b/.github/workflows/api_test.yml
@@ -23,6 +23,12 @@ jobs:
       name: Lint production image
       with:
         dockerfile: Dockerfile
+    
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1.8.0
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Build container
       run: docker build . -t api

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,12 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     
+    - name: Pull and rebuild dependencies image
+      run: |
+        docker pull lkjaero/foreign-language-reader-api:builder
+        docker build . -f Dockerfile_builder -t lkjaero/foreign-language-reader-api:builder
+        docker push lkjaero/foreign-language-reader-api:builder
+    
     - name: Build container
       run: docker build . -t lkjaero/foreign-language-reader-api:LATEST
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,33 +33,29 @@ jobs:
 
     - name: Get release version
       run: echo "RELEASE_VERSION=`cat version.sbt | grep -Eo "[0-9\.]+"`" >> $GITHUB_ENV
-    
-    - name: Print release version
-      run: echo $RELEASE_VERSIONs
 
-    - name: Save DigitalOcean kubeconfig
-      uses: digitalocean/action-doctl@v2.1.0
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1.8.0
       with:
-        token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     
     - name: Build container
-      run: docker build . -t api
+      run: docker build . -t lkjaero/foreign-language-reader-api:LATEST
 
     - name: Enforce security rules
       id: scan
       uses: anchore/scan-action@v2
       with:
-        image: "api:latest"
+        image: "lkjaero/foreign-language-reader-api:LATEST"
         fail-build: true
         acs-report-enable: true
 
-    - name: Log into docker
-      run: doctl registry login
-
     - name: Push container
       run: |
-        docker tag api:latest registry.digitalocean.com/foreign-language-reader/api:$RELEASE_VERSION
-        docker push registry.digitalocean.com/foreign-language-reader/api:$RELEASE_VERSION
+        docker tag lkjaero/foreign-language-reader-api:LATEST lkjaero/foreign-language-reader-api:$RELEASE_VERSION
+        docker push lkjaero/foreign-language-reader-api:$RELEASE_VERSION
+        docker push lkjaero/foreign-language-reader-api:LATEST
 
   deploy:
     name: Deploy API

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,22 +70,20 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
 
-      - name: Save DigitalOcean kubeconfig
+      - name: Log into DigitalOcean
         uses: digitalocean/action-doctl@v2.1.0
         with:
-          args: kubernetes cluster kubeconfig show foreign-language-reader > $GITHUB_WORKSPACE/.kubeconfig
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
+      - name: Save DigitalOcean kubeconfig
+        run: kubernetes cluster kubeconfig show foreign-language-reader > $GITHUB_WORKSPACE/.kubeconfig
+
       - name: Update image in K8s
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: foreign-language-reader-api
-          IMAGE_TAG: ${{ github.sha }}
         run: |
-          kubectl --kubeconfig=$GITHUB_WORKSPACE/.kubeconfig \
-            set image deployment/api api=registry.digitalocean.com/foreign-language-reader/api:$RELEASE_VERSION --record
+          kubectl --kubeconfig=$GITHUB_WORKSPACE/.kubeconfig -n prod \
+            set image deployment/api api=lkjaero/foreign-language-reader-api:$RELEASE_VERSION --record
 
       - name: Wait for deployment to finish
         run: |
-          kubectl --kubeconfig=$GITHUB_WORKSPACE/.kubeconfig \
+          kubectl --kubeconfig=$GITHUB_WORKSPACE/.kubeconfig -n prod \
             rollout status deployment/api

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,4 @@
-FROM openjdk:14-jdk-alpine3.10 as builder
-LABEL maintainer="reader@lucaskjaerozhang.com"
-
-ENV SBT_VERSION 1.4.0
-ENV INSTALL_DIR /usr/local
-ENV SBT_HOME /usr/local/sbt
-ENV PATH ${PATH}:${SBT_HOME}/bin
-
-# Sadly needed because package publishing requires this for all lifecycle steps.
-ENV GITHUB_TOKEN faketoken
-
-# Keep failing pipe command from reporting success to the build.
-SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
-
-# Install sbt
-RUN apk add --no-cache bash=5.0.0-r0 wget=1.20.3-r0 && \
-    mkdir -p "$SBT_HOME" && \
-    wget -qO - --no-check-certificate "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" |  tar xz -C $INSTALL_DIR && \
-    echo "- with sbt $SBT_VERSION" >> /root/.built
-
-# Cache dependencies
-WORKDIR /app
-COPY project project
-COPY build.sbt build.sbt
-RUN sbt compile
+FROM lkjaero/foreign-language-reader-api:builder as builder
 
 # Compile the service
 COPY . /app/
@@ -33,9 +9,7 @@ RUN unzip /app/api/target/universal/api-*.zip -d ./api
 ## Changes to string methods between versions has burned us before
 RUN sbt test
 
-FROM openjdk:14-jdk-alpine3.10 as final
-WORKDIR /app
-RUN apk add --no-cache bash=5.0.0-r0
+FROM lkjaero/foreign-language-reader-api:base as final
 EXPOSE 9000
 CMD ["/app/bin/api", "-Dconfig.resource=production.conf"]
 COPY --from=builder /app/api /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@ FROM lkjaero/foreign-language-reader-api:builder as builder
 COPY . /app/
 RUN sbt clean coverageOff dist
 
-# Detect the version and unzip to /app/dist 
+# Detect the version and unzip to /app/dist
+# hadolint disable=SC2086
 RUN VERSION=$(grep -Eo "[0-9\.]+" version.sbt) && \
     echo "Detected version $VERSION" && \
-    echo $VERSION > version.txt && \
     unzip /app/api/target/universal/api-$VERSION-SNAPSHOT.zip -d ./api && \
     mkdir dist && \
     mv api/api-$VERSION-SNAPSHOT/* dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . /app/
 RUN sbt clean coverageOff dist
 
 # Detect the version and unzip to /app/dist
-# hadolint disable=SC2086
+# hadolint ignore=SC2086
 RUN VERSION=$(grep -Eo "[0-9\.]+" version.sbt) && \
     echo "Detected version $VERSION" && \
     unzip /app/api/target/universal/api-$VERSION-SNAPSHOT.zip -d ./api && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . /app/
 RUN sbt clean coverageOff dist
 
 # Detect the version and unzip to /app/dist 
-RUN VERSION=`cat version.sbt | grep -Eo "[0-9\.]+"` && \
+RUN VERSION=$(grep -Eo "[0-9\.]+" version.sbt) && \
     echo "Detected version $VERSION" && \
     echo $VERSION > version.txt && \
     unzip /app/api/target/universal/api-$VERSION-SNAPSHOT.zip -d ./api && \

--- a/Dockerfile_base
+++ b/Dockerfile_base
@@ -1,0 +1,8 @@
+# Base docker environment for builder and deployment, used for a couple of things
+# - Keep all files on same os / java version
+# - Perform basic setup
+# - Prevent re-pulling from docker hub, to avoid rate limiting.
+FROM openjdk:16-ea-jdk-alpine3.12
+LABEL maintainer="reader@lucaskjaerozhang.com"
+WORKDIR /app
+RUN apk add --no-cache bash=5.0.17-r0

--- a/Dockerfile_builder
+++ b/Dockerfile_builder
@@ -1,0 +1,24 @@
+# Use this to cache project dependencies for easy building
+FROM lkjaero/foreign-language-reader-api:base
+
+ENV SBT_VERSION 1.4.0
+ENV INSTALL_DIR /usr/local
+ENV SBT_HOME /usr/local/sbt
+ENV PATH ${PATH}:${SBT_HOME}/bin
+
+# Sadly needed because package publishing requires this for all lifecycle steps.
+ENV GITHUB_TOKEN faketoken
+
+# Keep failing pipe command from reporting success to the build.
+SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+
+# Install sbt
+RUN apk add --no-cache wget=1.20.3-r1 && \
+    mkdir -p "$SBT_HOME" && \
+    wget -qO - --no-check-certificate "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" |  tar xz -C $INSTALL_DIR && \
+    echo "- with sbt $SBT_VERSION" >> /root/.built
+
+# Cache dependencies
+COPY project project
+COPY build.sbt build.sbt
+RUN sbt compile

--- a/api/conf/production.conf
+++ b/api/conf/production.conf
@@ -1,6 +1,9 @@
 # https://www.playframework.com/documentation/latest/Configuration
 include "secure"
 
+# Nginx will control access
+play.filters.disabled+=play.filters.hosts.AllowedHostsFilter
+
 # Application secret which comes from env variable
 play.http.secret.key="changeme"
 play.http.secret.key=${?APPLICATION_SECRET}


### PR DESCRIPTION
- Make base image for container
- Make builder image to cache dependencies
- Upgrade Java and Alpine versions to address security issues
- Fix broken unzip process in final release
- Switch to docker hub instead of digitalocean container repository