### PR TITLE
Get release version from latest tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,9 +26,10 @@ jobs:
       
       - name: Publish
         run: sbt "release with-defaults"
-      
+
       - name: Get release version
-        run: echo "RELEASE_VERSION=`cat version.sbt | grep -Eo "[0-9\.]+"`" >> $GITHUB_ENV
+        id: version
+        uses: WyriHaximus/github-action-get-previous-tag@1.0.0
       
       - name: Create Release
         id: create_release
@@ -36,8 +37,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: "v${{ env.RELEASE_VERSION }}"
-          release_name: ${{ github.event.pull_request.title }}
+          tag_name: ${{ steps.version.outputs.tag }}
+          release_name: "${{ env.RELEASE_VERSION }}: ${{ github.event.pull_request.title }}"
           body: ${{ github.event.pull_request.body }}
 
   build:
@@ -69,11 +70,15 @@ jobs:
         image: "lkjaero/foreign-language-reader-api:LATEST"
         fail-build: true
         acs-report-enable: true
+    
+    - name: Get release version
+      id: version
+      uses: WyriHaximus/github-action-get-previous-tag@1.0.0
 
     - name: Push container
       run: |
-        docker tag lkjaero/foreign-language-reader-api:LATEST lkjaero/foreign-language-reader-api:$RELEASE_VERSION
-        docker push lkjaero/foreign-language-reader-api:$RELEASE_VERSION
+        docker tag lkjaero/foreign-language-reader-api:LATEST lkjaero/foreign-language-reader-api:${{ steps.version.outputs.tag }}
+        docker push lkjaero/foreign-language-reader-api:${{ steps.version.outputs.tag }}
         docker push lkjaero/foreign-language-reader-api:LATEST
 
   deploy:
@@ -90,11 +95,15 @@ jobs:
 
       - name: Save DigitalOcean kubeconfig
         run: doctl kubernetes cluster kubeconfig show foreign-language-reader > $GITHUB_WORKSPACE/.kubeconfig
+      
+      - name: Get release version
+        id: version
+        uses: WyriHaximus/github-action-get-previous-tag@1.0.0
 
       - name: Update image in K8s
         run: |
           kubectl --kubeconfig=$GITHUB_WORKSPACE/.kubeconfig -n prod \
-            set image deployment/api api=lkjaero/foreign-language-reader-api:$RELEASE_VERSION --record
+            set image deployment/api api=lkjaero/foreign-language-reader-api:${{ steps.version.outputs.tag }} --record
 
       - name: Wait for deployment to finish
         run: |


### PR DESCRIPTION
Previously, current version is gotten from reading version.sbt. Unfortunately, this is done after release, which actually gives the version for next release. This fixes that, by getting the value of the latest git tag, which contains the release version.