### PR TITLE
Bugfix: Elasticsearch working upsert

### DIFF
--- a/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchClient.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchClient.scala
@@ -83,6 +83,7 @@ class ElasticsearchClient @Inject() (
     breaker.withBreaker("Failed to multisearch")(Future {
       javaClient.msearch(request, RequestOptions.DEFAULT)
     }) map (response => {
+      logger.info(s"Received result from multisearch: $response")
       if (response.getResponses.length === 2) {
         val first =
           getResultsFromSearchResponse[T](
@@ -125,6 +126,7 @@ class ElasticsearchClient @Inject() (
   private[this] def getResultsFromSearchResponse[T](
       response: SearchResponse
   )(implicit reads: Reads[T]): Map[String, T] = {
+    logger.info(s"Getting results from search response: $response")
     val hits =
       response.getHits.getHits.toList.map(hit => getResultsFromSearchHit(hit))
     hits.flatten.toMap

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/searchstates/ElasticsearchSearchResult.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/searchstates/ElasticsearchSearchResult.scala
@@ -50,10 +50,16 @@ case class ElasticsearchSearchResult[T: Writes](
     if (refetched) {
       val attempt =
         LookupAttempt(index = index, fields = fields, count = fetchCount)
+
+      val indexRequest = new IndexRequest()
+        .source(Json.toJson(attempt).toString(), XContentType.JSON)
+        .index(attemptsIndex)
+
       lookupId match {
         case Some(id) =>
           new UpdateRequest(attemptsIndex, id)
-            .upsert(Json.toJson(attempt).toString(), XContentType.JSON)
+            .upsert(indexRequest.id(id))
+            .doc(indexRequest.id(id))
             .asRight
             .some
         case None =>


### PR DESCRIPTION
- Elasticsearch upserting did not work, because the API was used incorrectly
- Log elasticsearch responses to detect failures
- Catch elasticsearch parse exceptions, log the errors, and continue