### PR TITLE
Elasticsearch fixes

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.5.20-SNAPSHOT"
+version in ThisBuild := "1.5.21-SNAPSHOT"


### PR DESCRIPTION
Rerelease of 1.5.21 due to release script errors
- Elasticsearch upserting did not work, because the API was used incorrectly
- Log elasticsearch responses to detect failures
- Catch elasticsearch parse exceptions, log the errors, and continue
- Use java trust store to accept elasticsearch self signed certificate