### PR TITLE
If the release script breaks, overwrite previous packages

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,11 @@ lazy val settings = Seq(
     TokenSource.Environment("GITHUB_TOKEN"),
     TokenSource.GitConfig("github.token")
   ),
-  releaseVersionBump := sbtrelease.Version.Bump.Bugfix
+  releaseVersionBump := sbtrelease.Version.Bump.Bugfix,
+  publishConfiguration := publishConfiguration.value.withOverwrite(true),
+  publishLocalConfiguration := publishLocalConfiguration.value.withOverwrite(
+    true
+  )
 )
 
 lazy val global = project


### PR DESCRIPTION
This will always be because a previous release failed partway. Let's just continue it if this happens.