### PR TITLE
 Use new credentials store

### DIFF
--- a/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchClientConfig.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchClientConfig.scala
@@ -60,7 +60,7 @@ class ElasticsearchClientConfig @Inject() (
   }
 
   val sslContext: SSLContext = {
-    val keystorePath = os.root / "etc" / "estruststore" / "api_keystore.jks"
+    val keystorePath = os.root / "etc" / "flrcredentials" / "api_keystore.jks"
     if (os.exists(keystorePath)) {
       logger.info("Using custom trust store")
       Try {


### PR DESCRIPTION
Credentials volume was renamed to hold multiple credentials. This updates the code location so we can find it.