### PR TITLE
Bugfix: Don't enrich definitions if there are no definitions to enrich

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ project/project
 project/target
 target
 .bsp/sbt.json
+api/conf/localproduction.conf

--- a/api/app/Log4J2LoggerConfigurator.scala
+++ b/api/app/Log4J2LoggerConfigurator.scala
@@ -1,0 +1,60 @@
+import java.io.File
+import java.net.URL
+
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.core.LoggerContext
+import org.apache.logging.log4j.core.config.Configurator
+import org.slf4j.ILoggerFactory
+import play.api.{Configuration, Environment, LoggerConfigurator, Mode}
+
+class Log4J2LoggerConfigurator extends LoggerConfigurator {
+
+  private lazy val factory: ILoggerFactory =
+    org.slf4j.impl.StaticLoggerBinder.getSingleton.getLoggerFactory
+
+  override def init(rootPath: File, mode: Mode): Unit = {
+    val properties = Map("application.home" -> rootPath.getAbsolutePath)
+    val resourceName = "log4j2.xml"
+    val resourceUrl = Option(
+      this.getClass.getClassLoader.getResource(resourceName)
+    )
+    configure(properties, resourceUrl)
+  }
+
+  override def shutdown(): Unit = {
+    val context = LogManager.getContext().asInstanceOf[LoggerContext]
+    Configurator.shutdown(context)
+  }
+
+  override def configure(env: Environment): Unit = {
+    val properties =
+      LoggerConfigurator.generateProperties(env, Configuration.empty, Map.empty)
+    val resourceUrl = env.resource("log4j2.xml")
+    configure(properties, resourceUrl)
+  }
+
+  override def configure(
+      env: Environment,
+      configuration: Configuration,
+      optionalProperties: Map[String, String]
+  ): Unit = {
+    // LoggerConfigurator.generateProperties enables play.logger.includeConfigProperties=true
+    val properties = LoggerConfigurator.generateProperties(
+      env,
+      configuration,
+      optionalProperties
+    )
+    val resourceUrl = env.resource("log4j2.xml")
+    configure(properties, resourceUrl)
+  }
+
+  override def configure(
+      properties: Map[String, String],
+      config: Option[URL]
+  ): Unit = {
+    val context = LogManager.getContext(false).asInstanceOf[LoggerContext]
+    context.setConfigLocation(config.get.toURI)
+  }
+
+  override def loggerFactory: ILoggerFactory = factory
+}

--- a/api/conf/log4j2.xml
+++ b/api/conf/log4j2.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="DEBUG">
+<Configuration status="INFO">
     <Appenders>
         <Console name="STDOUT" target="SYSTEM_OUT">
             <JSONLayout eventEol="true" compact="true"/>
         </Console>
     </Appenders>
     <Loggers>
-        <root level="debug">
+        <root level="info">
             <AppenderRef ref="STDOUT"/>
         </root>
     </Loggers>

--- a/api/conf/logger-configurator.properties
+++ b/api/conf/logger-configurator.properties
@@ -1,0 +1,1 @@
+play.logger.configurator=Log4J2LoggerConfigurator

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/service/definition/ChineseDefinitionService.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/service/definition/ChineseDefinitionService.scala
@@ -122,6 +122,7 @@ class ChineseDefinitionService @Inject() (
         val message =
           s"Definitions were lost for chinese word $word, check the request partitioner"
         logger.error(message)
+        logger.warn(s"Raw definitions for word $word: $definitions")
         throw new IllegalStateException(message)
     }
   }

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/service/definition/LanguageDefinitionService.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/service/definition/LanguageDefinitionService.scala
@@ -92,7 +92,9 @@ trait LanguageDefinitionService {
         }
       )
       .map(definitions =>
-        enrichDefinitions(definitionLanguage, word, definitions)
+        if (definitions.nonEmpty)
+          enrichDefinitions(definitionLanguage, word, definitions)
+        else List()
       )
   }
 


### PR DESCRIPTION
## Problem
There are enricher methods that combine definition results from multiple sources into one single list of results, filling in the blanks from one source with another. These methods expect results to combine, and do not appropriately handle no results.
## Solution
Check if results are empty before calling enricher methods.

## Also
Fixes to make logging work locally.