### PR TITLE
Bugfix: Chinese definition contains word language

### DIFF
--- a/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/WebsterDefinitionEntryBase.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/WebsterDefinitionEntryBase.scala
@@ -1,12 +1,12 @@
-package com.foreignlanguagereader.content.types.external.definition.webster.webster
+package com.foreignlanguagereader.content.types.external.definition.webster
 
-import com.foreignlanguagereader.content.types.external.definition.webster.webster.common.{
+import com.foreignlanguagereader.content.types.external.definition.webster.common.WebsterPartOfSpeech.WebsterPartOfSpeech
+import com.foreignlanguagereader.content.types.external.definition.webster.common.{
   WebsterDefinition,
   WebsterHeadwordInfo,
   WebsterMeta,
   WebsterPartOfSpeech
 }
-import com.foreignlanguagereader.content.types.external.definition.webster.webster.common.WebsterPartOfSpeech.WebsterPartOfSpeech
 import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech.PartOfSpeech
 
 trait WebsterDefinitionEntryBase {

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/WebsterLearnersDefinitionEntry.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/WebsterLearnersDefinitionEntry.scala
@@ -1,16 +1,10 @@
-package com.foreignlanguagereader.content.types.external.definition.webster.webster
+package com.foreignlanguagereader.content.types.external.definition.webster
 
 import com.foreignlanguagereader.content.types.Language
 import com.foreignlanguagereader.content.types.Language.Language
 import com.foreignlanguagereader.content.types.external.definition.DefinitionEntry
-import com.foreignlanguagereader.content.types.external.definition.webster.webster.common.WebsterPartOfSpeech.WebsterPartOfSpeech
-import com.foreignlanguagereader.content.types.external.definition.webster.webster.common.{
-  WebsterDefinedRunOnPhrase,
-  WebsterDefinition,
-  WebsterHeadwordInfo,
-  WebsterInflection,
-  WebsterMeta
-}
+import com.foreignlanguagereader.content.types.external.definition.webster.common.WebsterPartOfSpeech.WebsterPartOfSpeech
+import com.foreignlanguagereader.content.types.external.definition.webster.common._
 import com.foreignlanguagereader.content.types.internal.definition.DefinitionSource
 import com.foreignlanguagereader.content.types.internal.definition.DefinitionSource.DefinitionSource
 import com.foreignlanguagereader.content.util.JsonSequenceHelper

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/WebsterSpanishDefinitionEntry.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/WebsterSpanishDefinitionEntry.scala
@@ -1,17 +1,10 @@
-package com.foreignlanguagereader.content.types.external.definition.webster.webster
+package com.foreignlanguagereader.content.types.external.definition.webster
 
 import com.foreignlanguagereader.content.types.Language
 import com.foreignlanguagereader.content.types.Language.Language
 import com.foreignlanguagereader.content.types.external.definition.DefinitionEntry
-import com.foreignlanguagereader.content.types.external.definition.webster.webster.common.WebsterPartOfSpeech.WebsterPartOfSpeech
-import com.foreignlanguagereader.content.types.external.definition.webster.webster.common.{
-  WebsterDefinedRunOnPhrase,
-  WebsterDefinition,
-  WebsterHeadwordInfo,
-  WebsterInflection,
-  WebsterMeta,
-  WebsterPartOfSpeech
-}
+import com.foreignlanguagereader.content.types.external.definition.webster.common.WebsterPartOfSpeech.WebsterPartOfSpeech
+import com.foreignlanguagereader.content.types.external.definition.webster.common._
 import com.foreignlanguagereader.content.types.internal.definition.DefinitionSource
 import com.foreignlanguagereader.content.types.internal.definition.DefinitionSource.DefinitionSource
 import com.foreignlanguagereader.content.util.JsonSequenceHelper

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterDefinedRunOnPhrase.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterDefinedRunOnPhrase.scala
@@ -1,4 +1,4 @@
-package com.foreignlanguagereader.content.types.external.definition.webster.webster.common
+package com.foreignlanguagereader.content.types.external.definition.webster.common
 
 import com.foreignlanguagereader.content.util.JsonSequenceHelper
 import play.api.libs.functional.syntax._

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterDefiningText.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterDefiningText.scala
@@ -1,4 +1,4 @@
-package com.foreignlanguagereader.content.types.external.definition.webster.webster.common
+package com.foreignlanguagereader.content.types.external.definition.webster.common
 
 import com.foreignlanguagereader.content.util.JsonSequenceHelper
 import play.api.libs.functional.syntax._

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterDefinition.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterDefinition.scala
@@ -1,4 +1,4 @@
-package com.foreignlanguagereader.content.types.external.definition.webster.webster.common
+package com.foreignlanguagereader.content.types.external.definition.webster.common
 
 import com.foreignlanguagereader.content.util.JsonSequenceHelper
 import play.api.libs.functional.syntax._

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterHeadwordInfo.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterHeadwordInfo.scala
@@ -1,4 +1,4 @@
-package com.foreignlanguagereader.content.types.external.definition.webster.webster.common
+package com.foreignlanguagereader.content.types.external.definition.webster.common
 
 import play.api.libs.functional.syntax._
 import play.api.libs.json.{JsPath, Json, Reads, Writes}

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterInflection.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterInflection.scala
@@ -1,4 +1,4 @@
-package com.foreignlanguagereader.content.types.external.definition.webster.webster.common
+package com.foreignlanguagereader.content.types.external.definition.webster.common
 
 import com.foreignlanguagereader.content.util.JsonSequenceHelper
 import play.api.libs.functional.syntax._

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterMeta.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterMeta.scala
@@ -1,6 +1,6 @@
-package com.foreignlanguagereader.content.types.external.definition.webster.webster.common
+package com.foreignlanguagereader.content.types.external.definition.webster.common
 
-import com.foreignlanguagereader.content.types.external.definition.webster.webster.common.WebsterSource.WebsterSource
+import com.foreignlanguagereader.content.types.external.definition.webster.common.WebsterSource.WebsterSource
 import play.api.libs.functional.syntax._
 import play.api.libs.json.{JsPath, Json, Reads, Writes}
 

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterNestedArrayHelper.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterNestedArrayHelper.scala
@@ -1,4 +1,4 @@
-package com.foreignlanguagereader.content.types.external.definition.webster.webster.common
+package com.foreignlanguagereader.content.types.external.definition.webster.common
 
 import play.api.libs.json._
 

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterPartOfSpeech.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterPartOfSpeech.scala
@@ -1,4 +1,4 @@
-package com.foreignlanguagereader.content.types.external.definition.webster.webster.common
+package com.foreignlanguagereader.content.types.external.definition.webster.common
 
 import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech
 import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech.PartOfSpeech

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterPronunciation.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterPronunciation.scala
@@ -1,4 +1,4 @@
-package com.foreignlanguagereader.content.types.external.definition.webster.webster.common
+package com.foreignlanguagereader.content.types.external.definition.webster.common
 
 import com.foreignlanguagereader.content.util.JsonSequenceHelper
 import play.api.libs.functional.syntax._

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterSense.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterSense.scala
@@ -1,4 +1,4 @@
-package com.foreignlanguagereader.content.types.external.definition.webster.webster.common
+package com.foreignlanguagereader.content.types.external.definition.webster.common
 
 import com.foreignlanguagereader.content.util.JsonSequenceHelper
 import play.api.libs.functional.syntax._

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterVariant.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterVariant.scala
@@ -1,4 +1,4 @@
-package com.foreignlanguagereader.content.types.external.definition.webster.webster.common
+package com.foreignlanguagereader.content.types.external.definition.webster.common
 
 import com.foreignlanguagereader.content.util.JsonSequenceHelper
 import play.api.libs.functional.syntax._

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/internal/definition/ChineseDefinition.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/internal/definition/ChineseDefinition.scala
@@ -16,7 +16,9 @@ import com.foreignlanguagereader.dto.v1.definition.chinese.{
   HSKLevel
 }
 import com.github.houbb.opencc4j.util.ZhConverterUtil
+import play.api.libs.functional.syntax.toFunctionalBuilderOps
 import play.api.libs.json._
+
 import scala.collection.JavaConverters._
 import scala.compat.java8.OptionConverters._
 
@@ -34,7 +36,7 @@ case class ChineseDefinition(
     override val token: String
 ) extends Definition {
   private[this] val isTraditional = ZhConverterUtil.isTraditional(token)
-  val wordLanguage: Language =
+  override val wordLanguage: Language =
     if (isTraditional) Language.CHINESE_TRADITIONAL else Language.CHINESE
 
   val pronunciation: ChinesePronunciation =
@@ -74,6 +76,11 @@ case class ChineseDefinition(
     )
 }
 object ChineseDefinition {
-  implicit val format: Format[ChineseDefinition] =
-    Json.format[ChineseDefinition]
+  implicit val writes: Writes[ChineseDefinition] = {
+    (Json.writes[ChineseDefinition] ~ (__ \ "wordLanguage").write[Language])(
+      (d: ChineseDefinition) => (d, d.wordLanguage)
+    )
+
+  }
+  implicit val reads: Reads[ChineseDefinition] = Json.reads[ChineseDefinition]
 }

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/internal/definition/Definition.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/internal/definition/Definition.scala
@@ -61,13 +61,13 @@ object Definition {
     new Format[Definition] {
       override def reads(json: JsValue): JsResult[Definition] = {
         (json \ "wordLanguage").validate[Language] match {
-          case Language.CHINESE => ChineseDefinition.format.reads(json)
+          case Language.CHINESE => ChineseDefinition.reads.reads(json)
           case _                => GenericDefinition.format.reads(json)
         }
       }
       override def writes(o: Definition): JsValue =
         o match {
-          case c: ChineseDefinition => ChineseDefinition.format.writes(c)
+          case c: ChineseDefinition => ChineseDefinition.writes.writes(c)
           case g: GenericDefinition => GenericDefinition.format.writes(g)
         }
     }

--- a/content/src/test/scala/com/foreignlanguagereader/content/types/external/definition/webster/WebsterLearnersDefinitionEntryTest.scala
+++ b/content/src/test/scala/com/foreignlanguagereader/content/types/external/definition/webster/WebsterLearnersDefinitionEntryTest.scala
@@ -1,7 +1,6 @@
-package com.foreignlanguagereader.content.types.external.definition.webster.webster
+package com.foreignlanguagereader.content.types.external.definition.webster
 
 import com.foreignlanguagereader.content.types.Language
-import com.foreignlanguagereader.content.types.external.definition.webster.webster.WebsterLearnersDefinitionEntry.writes
 import com.foreignlanguagereader.content.types.internal.definition.{
   Definition,
   DefinitionSource

--- a/content/src/test/scala/com/foreignlanguagereader/content/types/external/definition/webster/WebsterSpanishDefinitionEntryTest.scala
+++ b/content/src/test/scala/com/foreignlanguagereader/content/types/external/definition/webster/WebsterSpanishDefinitionEntryTest.scala
@@ -1,7 +1,6 @@
-package com.foreignlanguagereader.content.types.external.definition.webster.webster
+package com.foreignlanguagereader.content.types.external.definition.webster
 
 import com.foreignlanguagereader.content.types.Language
-import com.foreignlanguagereader.content.types.external.definition.webster.webster.WebsterSpanishDefinitionEntry.writes
 import com.foreignlanguagereader.content.types.internal.definition.{
   Definition,
   DefinitionSource

--- a/content/src/test/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterDefinedRunOnPhraseTest.scala
+++ b/content/src/test/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterDefinedRunOnPhraseTest.scala
@@ -1,4 +1,4 @@
-package com.foreignlanguagereader.content.types.external.definition.webster.webster.common
+package com.foreignlanguagereader.content.types.external.definition.webster.common
 
 import org.scalatest.funspec.AnyFunSpec
 import play.api.libs.json.Json

--- a/content/src/test/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterDefiningTextTest.scala
+++ b/content/src/test/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterDefiningTextTest.scala
@@ -1,4 +1,4 @@
-package com.foreignlanguagereader.content.types.external.definition.webster.webster.common
+package com.foreignlanguagereader.content.types.external.definition.webster.common
 
 import org.scalatest.funspec.AnyFunSpec
 import play.api.libs.json.Json

--- a/content/src/test/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterDefinitionTest.scala
+++ b/content/src/test/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterDefinitionTest.scala
@@ -1,4 +1,4 @@
-package com.foreignlanguagereader.content.types.external.definition.webster.webster.common
+package com.foreignlanguagereader.content.types.external.definition.webster.common
 
 import org.scalatest.funspec.AnyFunSpec
 import play.api.libs.json.Json

--- a/content/src/test/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterHeadwordInfoTest.scala
+++ b/content/src/test/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterHeadwordInfoTest.scala
@@ -1,4 +1,4 @@
-package com.foreignlanguagereader.content.types.external.definition.webster.webster.common
+package com.foreignlanguagereader.content.types.external.definition.webster.common
 
 import org.scalatest.funspec.AnyFunSpec
 import play.api.libs.json.Json

--- a/content/src/test/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterInflectionTest.scala
+++ b/content/src/test/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterInflectionTest.scala
@@ -1,4 +1,4 @@
-package com.foreignlanguagereader.content.types.external.definition.webster.webster.common
+package com.foreignlanguagereader.content.types.external.definition.webster.common
 
 import org.scalatest.funspec.AnyFunSpec
 import play.api.libs.json.Json

--- a/content/src/test/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterMetaTest.scala
+++ b/content/src/test/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterMetaTest.scala
@@ -1,4 +1,4 @@
-package com.foreignlanguagereader.content.types.external.definition.webster.webster.common
+package com.foreignlanguagereader.content.types.external.definition.webster.common
 
 import org.scalatest.funspec.AnyFunSpec
 import play.api.libs.json.Json

--- a/content/src/test/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterSenseTest.scala
+++ b/content/src/test/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterSenseTest.scala
@@ -1,4 +1,4 @@
-package com.foreignlanguagereader.content.types.external.definition.webster.webster.common
+package com.foreignlanguagereader.content.types.external.definition.webster.common
 
 import org.scalatest.funspec.AnyFunSpec
 import play.api.libs.json.Json

--- a/content/src/test/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterVariantTest.scala
+++ b/content/src/test/scala/com/foreignlanguagereader/content/types/external/definition/webster/common/WebsterVariantTest.scala
@@ -1,4 +1,4 @@
-package com.foreignlanguagereader.content.types.external.definition.webster.webster.common
+package com.foreignlanguagereader.content.types.external.definition.webster.common
 
 import org.scalatest.funspec.AnyFunSpec
 import play.api.libs.json.Json

--- a/content/src/test/scala/com/foreignlanguagereader/content/types/internal/definition/ChineseDefinitionTest.scala
+++ b/content/src/test/scala/com/foreignlanguagereader/content/types/internal/definition/ChineseDefinitionTest.scala
@@ -4,7 +4,7 @@ import com.foreignlanguagereader.content.types.Language
 import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech
 import com.foreignlanguagereader.dto.v1.definition.chinese.HSKLevel
 import org.scalatest.funspec.AnyFunSpec
-import play.api.libs.json.{JsError, JsSuccess, Json}
+import play.api.libs.json.Json
 
 import scala.collection.JavaConverters._
 import scala.compat.java8.OptionConverters._

--- a/content/src/test/scala/com/foreignlanguagereader/content/types/internal/definition/ChineseDefinitionTest.scala
+++ b/content/src/test/scala/com/foreignlanguagereader/content/types/internal/definition/ChineseDefinitionTest.scala
@@ -2,9 +2,10 @@ package com.foreignlanguagereader.content.types.internal.definition
 
 import com.foreignlanguagereader.content.types.Language
 import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech
-import com.foreignlanguagereader.dto.v1.definition.ChineseDefinitionDTO
 import com.foreignlanguagereader.dto.v1.definition.chinese.HSKLevel
 import org.scalatest.funspec.AnyFunSpec
+import play.api.libs.json.{JsError, JsSuccess, Json}
+
 import scala.collection.JavaConverters._
 import scala.compat.java8.OptionConverters._
 
@@ -102,6 +103,14 @@ class ChineseDefinitionTest extends AnyFunSpec {
       )
       assert(example.pronunciation.pinyin == converted.getPronunciation)
       assert(example.hsk == converted.getHsk)
+    }
+
+    it("can correctly serialize itself to JSON") {
+      val json: String = Json.stringify(Json.toJson(example))
+      // These matter for elasticsearch lookup to work
+      assert(json.contains("\"definitionLanguage\":\"ENGLISH\""))
+      assert(json.contains("\"source\":\"MULTIPLE\""))
+      assert(json.contains("\"wordLanguage\":\"CHINESE\""))
     }
   }
 }

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/client/MirriamWebsterClient.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/client/MirriamWebsterClient.scala
@@ -5,10 +5,11 @@ import java.util.concurrent.TimeUnit
 import akka.actor.ActorSystem
 import cats.data.Nested
 import cats.implicits._
-import com.foreignlanguagereader.content.types.external.definition.webster.webster.{
+import com.foreignlanguagereader.content.types.external.definition.webster.{
   WebsterLearnersDefinitionEntry,
   WebsterSpanishDefinitionEntry
 }
+import com.foreignlanguagereader.content.types.external.definition.webster.WebsterSpanishDefinitionEntry
 import com.foreignlanguagereader.content.types.internal.definition.Definition
 import com.foreignlanguagereader.content.types.internal.word.Word
 import com.foreignlanguagereader.domain.client.common.{


### PR DESCRIPTION
## Problem
When looking up definition results from elasticsearch, we need the definition language, the word language, and the definition source. However, ChineseDefinitions don't take the word language as a parameter because it is obvious. This means that it is not serialized to JSON, and is missing from elasticsearch.

## Solution
Manually add definition language to the fields written to JSON

## Also
Webster domain types are kept in a duplicate package: `webster.webster`. I moved them to the correct spot.