### PR TITLE
Chinese definitions are all stored as simplified

### DIFF
--- a/content/src/main/scala/com/foreignlanguagereader/content/types/internal/definition/ChineseDefinition.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/internal/definition/ChineseDefinition.scala
@@ -78,7 +78,7 @@ case class ChineseDefinition(
 object ChineseDefinition {
   implicit val writes: Writes[ChineseDefinition] = {
     (Json.writes[ChineseDefinition] ~ (__ \ "wordLanguage").write[Language])(
-      (d: ChineseDefinition) => (d, d.wordLanguage)
+      (d: ChineseDefinition) => (d, Language.CHINESE)
     )
 
   }


### PR DESCRIPTION
Definitions are all stored as simplified for lookup. The definitions are the same either way.