### PR TITLE
Feature: Store definition entries instead of definitions in cache

### DIFF
--- a/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/DefinitionEntry.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/DefinitionEntry.scala
@@ -1,15 +1,10 @@
 package com.foreignlanguagereader.content.types.external.definition
 
-import com.foreignlanguagereader.content.types.Language
 import com.foreignlanguagereader.content.types.Language.Language
 import com.foreignlanguagereader.content.types.external.definition.cedict.CEDICTDefinitionEntry
 import com.foreignlanguagereader.content.types.external.definition.wiktionary.WiktionaryDefinitionEntry
-import com.foreignlanguagereader.content.types.internal.definition.{
-  ChineseDefinition,
-  Definition,
-  DefinitionSource
-}
 import com.foreignlanguagereader.content.types.internal.definition.DefinitionSource.DefinitionSource
+import com.foreignlanguagereader.content.types.internal.definition._
 import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech.PartOfSpeech
 import play.api.libs.json._
 
@@ -24,29 +19,7 @@ trait DefinitionEntry {
   val source: DefinitionSource
   val token: String
 
-  def toDefinition(partOfSpeech: PartOfSpeech): Definition = {
-    val part = tag match {
-      case Some(t) => t
-      case None    => partOfSpeech
-    }
-    wordLanguage match {
-      case Language.CHINESE =>
-        DefinitionEntry.buildChineseDefinition(this, part)
-      case Language.CHINESE_TRADITIONAL =>
-        DefinitionEntry.buildChineseDefinition(this, part)
-      case _ =>
-        Definition(
-          subdefinitions = subdefinitions,
-          ipa = pronunciation,
-          tag = part,
-          examples = examples,
-          wordLanguage = wordLanguage,
-          definitionLanguage = definitionLanguage,
-          source = source,
-          token = token
-        )
-    }
-  }
+  def toDefinition(partOfSpeech: PartOfSpeech): Definition
 }
 
 object DefinitionEntry {
@@ -92,6 +65,36 @@ object DefinitionEntry {
       inputPinyin = entry.pronunciation,
       inputSimplified = None,
       inputTraditional = None,
+      definitionLanguage = entry.definitionLanguage,
+      source = entry.source,
+      token = entry.token
+    )
+
+  def buildEnglishDefinition(
+      entry: DefinitionEntry,
+      partOfSpeech: PartOfSpeech
+  ): EnglishDefinition =
+    EnglishDefinition(
+      subdefinitions = entry.subdefinitions,
+      ipa = entry.pronunciation,
+      tag = partOfSpeech,
+      examples = entry.examples,
+      wordLanguage = entry.wordLanguage,
+      definitionLanguage = entry.definitionLanguage,
+      source = entry.source,
+      token = entry.token
+    )
+
+  def buildSpanishDefinition(
+      entry: DefinitionEntry,
+      partOfSpeech: PartOfSpeech
+  ): SpanishDefinition =
+    SpanishDefinition(
+      subdefinitions = entry.subdefinitions,
+      ipa = entry.pronunciation,
+      tag = partOfSpeech,
+      examples = entry.examples,
+      wordLanguage = entry.wordLanguage,
       definitionLanguage = entry.definitionLanguage,
       source = entry.source,
       token = entry.token

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/cedict/CEDICTDefinitionEntry.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/cedict/CEDICTDefinitionEntry.scala
@@ -3,12 +3,11 @@ package com.foreignlanguagereader.content.types.external.definition.cedict
 import com.foreignlanguagereader.content.types.Language
 import com.foreignlanguagereader.content.types.Language.Language
 import com.foreignlanguagereader.content.types.external.definition.DefinitionEntry
+import com.foreignlanguagereader.content.types.internal.definition.DefinitionSource.DefinitionSource
 import com.foreignlanguagereader.content.types.internal.definition.{
   ChineseDefinition,
-  Definition,
   DefinitionSource
 }
-import com.foreignlanguagereader.content.types.internal.definition.DefinitionSource.DefinitionSource
 import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech.PartOfSpeech
 import play.api.libs.json.{Format, Json, Reads}
 
@@ -28,7 +27,7 @@ case class CEDICTDefinitionEntry(
   override val source: DefinitionSource = DefinitionSource.CEDICT
 
   // We clearly do have simplified and traditional values so let's use them.
-  override def toDefinition(partOfSpeech: PartOfSpeech): Definition =
+  override def toDefinition(partOfSpeech: PartOfSpeech): ChineseDefinition =
     ChineseDefinition(
       subdefinitions = subdefinitions,
       tag = partOfSpeech,

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/WebsterLearnersDefinitionEntry.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/WebsterLearnersDefinitionEntry.scala
@@ -5,8 +5,12 @@ import com.foreignlanguagereader.content.types.Language.Language
 import com.foreignlanguagereader.content.types.external.definition.DefinitionEntry
 import com.foreignlanguagereader.content.types.external.definition.webster.common.WebsterPartOfSpeech.WebsterPartOfSpeech
 import com.foreignlanguagereader.content.types.external.definition.webster.common._
-import com.foreignlanguagereader.content.types.internal.definition.DefinitionSource
+import com.foreignlanguagereader.content.types.internal.definition.{
+  Definition,
+  DefinitionSource
+}
 import com.foreignlanguagereader.content.types.internal.definition.DefinitionSource.DefinitionSource
+import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech.PartOfSpeech
 import com.foreignlanguagereader.content.util.JsonSequenceHelper
 import play.api.libs.functional.syntax._
 import play.api.libs.json.{JsPath, Json, Reads, Writes}
@@ -31,6 +35,8 @@ case class WebsterLearnersDefinitionEntry(
   // Or non-standard
   // Learners may not even want to see obsolete words
   // And definitely should be discouraged from adding them to their vocabulary list.
+  override def toDefinition(partOfSpeech: PartOfSpeech): Definition =
+    DefinitionEntry.buildEnglishDefinition(this, partOfSpeech)
 }
 object WebsterLearnersDefinitionEntry {
   implicit val reads: Reads[WebsterLearnersDefinitionEntry] = (

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/WebsterSpanishDefinitionEntry.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/webster/WebsterSpanishDefinitionEntry.scala
@@ -5,8 +5,12 @@ import com.foreignlanguagereader.content.types.Language.Language
 import com.foreignlanguagereader.content.types.external.definition.DefinitionEntry
 import com.foreignlanguagereader.content.types.external.definition.webster.common.WebsterPartOfSpeech.WebsterPartOfSpeech
 import com.foreignlanguagereader.content.types.external.definition.webster.common._
-import com.foreignlanguagereader.content.types.internal.definition.DefinitionSource
+import com.foreignlanguagereader.content.types.internal.definition.{
+  Definition,
+  DefinitionSource
+}
 import com.foreignlanguagereader.content.types.internal.definition.DefinitionSource.DefinitionSource
+import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech.PartOfSpeech
 import com.foreignlanguagereader.content.util.JsonSequenceHelper
 import play.api.libs.functional.syntax._
 import play.api.libs.json.{JsPath, Json, Reads, Writes}
@@ -40,6 +44,17 @@ case class WebsterSpanishDefinitionEntry(
     WebsterPartOfSpeech.parseFromString(partOfSpeechRaw)
 
   // TODO gender
+  override def toDefinition(partOfSpeech: PartOfSpeech): Definition =
+    wordLanguage match {
+      case Language.ENGLISH =>
+        DefinitionEntry.buildEnglishDefinition(this, partOfSpeech)
+      case Language.SPANISH =>
+        DefinitionEntry.buildSpanishDefinition(this, partOfSpeech)
+      case l =>
+        throw new IllegalStateException(
+          s"Tried to convert a WebsterSpanishDefinitionEntry to $l"
+        )
+    }
 }
 object WebsterSpanishDefinitionEntry {
   implicit val reads: Reads[WebsterSpanishDefinitionEntry] = (

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/wiktionary/SimpleWiktionaryDefinitionEntry.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/wiktionary/SimpleWiktionaryDefinitionEntry.scala
@@ -5,7 +5,10 @@ import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech
 import com.foreignlanguagereader.content.types.Language.Language
 import PartOfSpeech.PartOfSpeech
 import com.foreignlanguagereader.content.types.Language
-import com.foreignlanguagereader.content.types.internal.definition.DefinitionSource
+import com.foreignlanguagereader.content.types.internal.definition.{
+  Definition,
+  DefinitionSource
+}
 import com.foreignlanguagereader.content.types.internal.definition.DefinitionSource.DefinitionSource
 
 case class SimpleWiktionaryDefinitionEntry(
@@ -34,4 +37,7 @@ case class SimpleWiktionaryDefinitionEntry(
   override val pronunciation: String = pronunciationRaw.head
   override val tag: Option[PartOfSpeech] = Some(PartOfSpeech.withName(tagRaw))
   override val examples: Option[List[String]] = Some(examplesRaw)
+
+  override def toDefinition(partOfSpeech: PartOfSpeech): Definition =
+    DefinitionEntry.buildEnglishDefinition(this, partOfSpeech)
 }

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/wiktionary/WiktionaryDefinitionEntry.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/external/definition/wiktionary/WiktionaryDefinitionEntry.scala
@@ -1,8 +1,12 @@
 package com.foreignlanguagereader.content.types.external.definition.wiktionary
 
+import com.foreignlanguagereader.content.types.Language
 import com.foreignlanguagereader.content.types.Language.Language
 import com.foreignlanguagereader.content.types.external.definition.DefinitionEntry
-import com.foreignlanguagereader.content.types.internal.definition.DefinitionSource
+import com.foreignlanguagereader.content.types.internal.definition.{
+  Definition,
+  DefinitionSource
+}
 import com.foreignlanguagereader.content.types.internal.definition.DefinitionSource.DefinitionSource
 import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech.PartOfSpeech
 import play.api.libs.json.{Format, Json, Reads}
@@ -16,7 +20,19 @@ case class WiktionaryDefinitionEntry(
     override val definitionLanguage: Language,
     override val token: String,
     override val source: DefinitionSource = DefinitionSource.WIKTIONARY
-) extends DefinitionEntry
+) extends DefinitionEntry {
+  override def toDefinition(partOfSpeech: PartOfSpeech): Definition =
+    wordLanguage match {
+      case Language.CHINESE =>
+        DefinitionEntry.buildChineseDefinition(this, partOfSpeech)
+      case Language.CHINESE_TRADITIONAL =>
+        DefinitionEntry.buildChineseDefinition(this, partOfSpeech)
+      case Language.ENGLISH =>
+        DefinitionEntry.buildEnglishDefinition(this, partOfSpeech)
+      case Language.SPANISH =>
+        DefinitionEntry.buildSpanishDefinition(this, partOfSpeech)
+    }
+}
 
 object WiktionaryDefinitionEntry {
   // Allows serializing and deserializing in json

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/internal/definition/ChineseDefinition.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/internal/definition/ChineseDefinition.scala
@@ -77,8 +77,9 @@ case class ChineseDefinition(
 }
 object ChineseDefinition {
   implicit val writes: Writes[ChineseDefinition] = {
-    (Json.writes[ChineseDefinition] ~ (__ \ "wordLanguage").write[Language])(
-      (d: ChineseDefinition) => (d, Language.CHINESE)
+    (Json.writes[ChineseDefinition] ~ (__ \ "wordLanguage")
+      .write[Language] ~ (__ \ "ipa").write[String])((d: ChineseDefinition) =>
+      (d, Language.CHINESE, d.ipa)
     )
 
   }

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/internal/definition/Definition.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/internal/definition/Definition.scala
@@ -1,13 +1,9 @@
 package com.foreignlanguagereader.content.types.internal.definition
 
-import com.foreignlanguagereader.content.types.Language
 import com.foreignlanguagereader.content.types.Language.Language
-import com.foreignlanguagereader.content.types.internal.definition
 import com.foreignlanguagereader.content.types.internal.definition.DefinitionSource.DefinitionSource
 import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech.PartOfSpeech
-import com.foreignlanguagereader.content.util.JsonSequenceHelper
 import com.foreignlanguagereader.dto.v1.definition.DefinitionDTO
-import play.api.libs.json._
 
 trait Definition {
   val subdefinitions: List[String]
@@ -28,49 +24,4 @@ trait Definition {
 
   // This always needs to know how to convert itself to a DTO
   val toDTO: DefinitionDTO
-}
-
-object Definition {
-  def apply(
-      subdefinitions: List[String],
-      ipa: String,
-      tag: PartOfSpeech,
-      examples: Option[List[String]],
-      wordLanguage: Language,
-      definitionLanguage: Language,
-      source: DefinitionSource,
-      token: String
-  ): Definition =
-    definition.GenericDefinition(
-      subdefinitions,
-      ipa,
-      tag,
-      examples,
-      wordLanguage,
-      definitionLanguage,
-      source,
-      token
-    )
-  def definitionListToDefinitionDTOList(
-      definitions: Seq[Definition]
-  ): Seq[DefinitionDTO] =
-    definitions.map(x => x.toDTO)
-
-  // Json
-  implicit val format: Format[Definition] =
-    new Format[Definition] {
-      override def reads(json: JsValue): JsResult[Definition] = {
-        (json \ "wordLanguage").validate[Language] match {
-          case Language.CHINESE => ChineseDefinition.reads.reads(json)
-          case _                => GenericDefinition.format.reads(json)
-        }
-      }
-      override def writes(o: Definition): JsValue =
-        o match {
-          case c: ChineseDefinition => ChineseDefinition.writes.writes(c)
-          case g: GenericDefinition => GenericDefinition.format.writes(g)
-        }
-    }
-  implicit val helper: JsonSequenceHelper[Definition] =
-    new JsonSequenceHelper[Definition]
 }

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/internal/definition/EnglishDefinition.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/internal/definition/EnglishDefinition.scala
@@ -5,10 +5,10 @@ import com.foreignlanguagereader.content.types.internal.definition.DefinitionSou
 import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech
 import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech.PartOfSpeech
 import com.foreignlanguagereader.dto.v1.definition.DefinitionDTO
-import play.api.libs.json.{Format, Json}
+
 import scala.collection.JavaConverters._
 
-case class GenericDefinition(
+case class EnglishDefinition(
     subdefinitions: List[String],
     ipa: String,
     tag: PartOfSpeech,
@@ -29,8 +29,4 @@ case class GenericDefinition(
       PartOfSpeech.toDTO(tag),
       examples.getOrElse(List()).asJava
     )
-}
-object GenericDefinition {
-  implicit val format: Format[GenericDefinition] =
-    Json.format[GenericDefinition]
 }

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/internal/definition/SpanishDefinition.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/internal/definition/SpanishDefinition.scala
@@ -1,0 +1,32 @@
+package com.foreignlanguagereader.content.types.internal.definition
+
+import com.foreignlanguagereader.content.types.Language.Language
+import com.foreignlanguagereader.content.types.internal.definition.DefinitionSource.DefinitionSource
+import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech
+import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech.PartOfSpeech
+import com.foreignlanguagereader.dto.v1.definition.DefinitionDTO
+
+import scala.collection.JavaConverters._
+
+case class SpanishDefinition(
+    subdefinitions: List[String],
+    ipa: String,
+    tag: PartOfSpeech,
+    examples: Option[List[String]],
+    // These fields are needed for elasticsearch lookup
+    // But do not need to be presented to the user.
+    definitionLanguage: Language,
+    wordLanguage: Language,
+    source: DefinitionSource,
+    token: String
+) extends Definition {
+  val id: String = generateId()
+
+  override lazy val toDTO: DefinitionDTO =
+    new DefinitionDTO(
+      id,
+      subdefinitions.asJava,
+      PartOfSpeech.toDTO(tag),
+      examples.getOrElse(List()).asJava
+    )
+}

--- a/content/src/test/scala/com/foreignlanguagereader/content/types/external/definition/webster/WebsterLearnersDefinitionEntryTest.scala
+++ b/content/src/test/scala/com/foreignlanguagereader/content/types/external/definition/webster/WebsterLearnersDefinitionEntryTest.scala
@@ -2,8 +2,8 @@ package com.foreignlanguagereader.content.types.external.definition.webster
 
 import com.foreignlanguagereader.content.types.Language
 import com.foreignlanguagereader.content.types.internal.definition.{
-  Definition,
-  DefinitionSource
+  DefinitionSource,
+  EnglishDefinition
 }
 import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech
 import com.foreignlanguagereader.content.util.ContentFileLoader
@@ -63,7 +63,7 @@ class WebsterLearnersDefinitionEntryTest extends AnyFunSpec {
         val definitionLanguage = Language.ENGLISH
         val source = DefinitionSource.MIRRIAM_WEBSTER_LEARNERS
 
-        val compareAgainst = Definition(
+        val compareAgainst = EnglishDefinition(
           subdefinitions,
           ipa,
           tag,

--- a/content/src/test/scala/com/foreignlanguagereader/content/types/external/definition/webster/WebsterSpanishDefinitionEntryTest.scala
+++ b/content/src/test/scala/com/foreignlanguagereader/content/types/external/definition/webster/WebsterSpanishDefinitionEntryTest.scala
@@ -1,11 +1,14 @@
 package com.foreignlanguagereader.content.types.external.definition.webster
 
 import com.foreignlanguagereader.content.types.Language
+import com.foreignlanguagereader.content.types.Language.Language
+import com.foreignlanguagereader.content.types.internal.definition.DefinitionSource.DefinitionSource
 import com.foreignlanguagereader.content.types.internal.definition.{
   DefinitionSource,
-  SpanishDefinition
+  EnglishDefinition
 }
 import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech
+import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech.PartOfSpeech
 import com.foreignlanguagereader.content.util.ContentFileLoader
 import org.scalatest.funspec.AnyFunSpec
 import play.api.libs.json.{JsValue, Json}
@@ -41,22 +44,18 @@ class WebsterSpanishDefinitionEntryTest extends AnyFunSpec {
       }
 
       it("can convert to a Definition") {
-        val wordLanguage = Language.ENGLISH
-        val definitionLanguage = Language.SPANISH
-        val source = DefinitionSource.MIRRIAM_WEBSTER_SPANISH
+        val testDefinition = webster.head.toDefinition(PartOfSpeech.NOUN)
 
-        val compareAgainst = SpanishDefinition(
-          subdefinitions,
-          ipa,
-          tag,
-          examples,
-          wordLanguage,
-          definitionLanguage,
-          source,
-          token
+        assert(testDefinition.subdefinitions == subdefinitions)
+        assert(testDefinition.ipa == ipa)
+        assert(testDefinition.tag == tag)
+        assert(testDefinition.examples == examples)
+        assert(testDefinition.definitionLanguage == Language.SPANISH)
+        assert(testDefinition.wordLanguage == Language.ENGLISH)
+        assert(
+          testDefinition.source == DefinitionSource.MIRRIAM_WEBSTER_SPANISH
         )
-
-        assert(webster.head.toDefinition(PartOfSpeech.NOUN) == compareAgainst)
+        assert(testDefinition.token == token)
       }
 
       it("can be written out to json") {

--- a/content/src/test/scala/com/foreignlanguagereader/content/types/external/definition/webster/WebsterSpanishDefinitionEntryTest.scala
+++ b/content/src/test/scala/com/foreignlanguagereader/content/types/external/definition/webster/WebsterSpanishDefinitionEntryTest.scala
@@ -2,8 +2,8 @@ package com.foreignlanguagereader.content.types.external.definition.webster
 
 import com.foreignlanguagereader.content.types.Language
 import com.foreignlanguagereader.content.types.internal.definition.{
-  Definition,
-  DefinitionSource
+  DefinitionSource,
+  SpanishDefinition
 }
 import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech
 import com.foreignlanguagereader.content.util.ContentFileLoader
@@ -45,7 +45,7 @@ class WebsterSpanishDefinitionEntryTest extends AnyFunSpec {
         val definitionLanguage = Language.SPANISH
         val source = DefinitionSource.MIRRIAM_WEBSTER_SPANISH
 
-        val compareAgainst = Definition(
+        val compareAgainst = SpanishDefinition(
           subdefinitions,
           ipa,
           tag,

--- a/content/src/test/scala/com/foreignlanguagereader/content/types/internal/definition/ChineseDefinitionTest.scala
+++ b/content/src/test/scala/com/foreignlanguagereader/content/types/internal/definition/ChineseDefinitionTest.scala
@@ -111,6 +111,7 @@ class ChineseDefinitionTest extends AnyFunSpec {
       assert(json.contains("\"definitionLanguage\":\"ENGLISH\""))
       assert(json.contains("\"source\":\"MULTIPLE\""))
       assert(json.contains("\"wordLanguage\":\"CHINESE\""))
+      assert(json.contains("\"ipa\":\"[ni] [xɑʊ̯]\""))
     }
   }
 }

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/client/MirriamWebsterClient.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/client/MirriamWebsterClient.scala
@@ -3,14 +3,10 @@ package com.foreignlanguagereader.domain.client
 import java.util.concurrent.TimeUnit
 
 import akka.actor.ActorSystem
-import cats.data.Nested
-import cats.implicits._
 import com.foreignlanguagereader.content.types.external.definition.webster.{
   WebsterLearnersDefinitionEntry,
   WebsterSpanishDefinitionEntry
 }
-import com.foreignlanguagereader.content.types.external.definition.webster.WebsterSpanishDefinitionEntry
-import com.foreignlanguagereader.content.types.internal.definition.Definition
 import com.foreignlanguagereader.content.types.internal.word.Word
 import com.foreignlanguagereader.domain.client.common.{
   CircuitBreakerResult,
@@ -55,21 +51,19 @@ class MirriamWebsterClient @Inject() (
 
   def getLearnersDefinition(
       word: Word
-  ): Nested[Future, CircuitBreakerResult, List[Definition]] =
+  ): Future[CircuitBreakerResult[List[WebsterLearnersDefinitionEntry]]] =
     client
       .get[List[WebsterLearnersDefinitionEntry]](
         s"https://www.dictionaryapi.com/api/v3/references/learners/json/${word.processedToken}?key=$learnersApiKey"
       )
-      .map(results => results.map(_.toDefinition(word.tag)))
 
   def getSpanishDefinition(
       word: Word
-  ): Nested[Future, CircuitBreakerResult, List[Definition]] =
+  ): Future[CircuitBreakerResult[List[WebsterSpanishDefinitionEntry]]] =
     client
       .get[List[WebsterSpanishDefinitionEntry]](
         s"https://www.dictionaryapi.com/api/v3/references/spanish/json/${word.processedToken}?key=$spanishApiKey"
       )
-      .map(results => results.map(_.toDefinition(word.tag)))
 
   def health(): ReadinessStatus = client.breaker.health()
 }

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/client/common/RestClient.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/client/common/RestClient.scala
@@ -3,7 +3,6 @@ package com.foreignlanguagereader.domain.client.common
 import java.util.concurrent.TimeUnit
 
 import akka.actor.ActorSystem
-import cats.data.Nested
 import javax.inject.Inject
 import play.api.Logger
 import play.api.libs.json.{JsError, JsSuccess, Reads}
@@ -30,7 +29,7 @@ case class RestClient(
 
   def get[T: ClassTag](
       url: String
-  )(implicit reads: Reads[T]): Nested[Future, CircuitBreakerResult, T] = {
+  )(implicit reads: Reads[T]): Future[CircuitBreakerResult[T]] = {
     val typeName = implicitly[ClassTag[T]].runtimeClass.getSimpleName
     val message = s"Failed to get $typeName from $url"
     get(url, message)
@@ -39,7 +38,7 @@ case class RestClient(
   def get[T: ClassTag](
       url: String,
       logIfError: String
-  )(implicit reads: Reads[T]): Nested[Future, CircuitBreakerResult, T] = {
+  )(implicit reads: Reads[T]): Future[CircuitBreakerResult[T]] = {
     logger.info(s"Calling url $url")
     val typeName = implicitly[ClassTag[T]].runtimeClass.getSimpleName
     breaker.withBreaker(logIfError) {

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/DefinitionFetcher.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/DefinitionFetcher.scala
@@ -1,0 +1,74 @@
+package com.foreignlanguagereader.domain.fetcher
+
+import com.foreignlanguagereader.content.types.Language.Language
+import com.foreignlanguagereader.content.types.external.definition.DefinitionEntry
+import com.foreignlanguagereader.content.types.internal.definition.Definition
+import com.foreignlanguagereader.content.types.internal.definition.DefinitionSource.DefinitionSource
+import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech.PartOfSpeech
+import com.foreignlanguagereader.content.types.internal.word.Word
+import com.foreignlanguagereader.domain.client.common.CircuitBreakerResult
+import com.foreignlanguagereader.domain.client.elasticsearch.ElasticsearchCacheClient
+import com.foreignlanguagereader.domain.client.elasticsearch.searchstates.ElasticsearchSearchRequest
+import play.api.libs.json.{Reads, Writes}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.reflect.ClassTag
+
+trait DefinitionFetcher[T <: DefinitionEntry, U <: Definition] {
+  def fetch(
+      language: Language,
+      word: Word
+  ): Future[CircuitBreakerResult[List[T]]]
+  def convertToDefinition(entry: T, tag: PartOfSpeech): U
+  implicit val reads: Reads[T]
+  implicit val writes: Writes[T]
+  implicit val ec: ExecutionContext
+
+  val maxFetchAttempts = 5
+
+  def fetchDefinitions(
+      elasticsearch: ElasticsearchCacheClient,
+      index: String,
+      definitionLanguage: Language,
+      wordLanguage: Language,
+      source: DefinitionSource,
+      word: Word
+  )(implicit tag: ClassTag[T]): Future[List[U]] = {
+    elasticsearch
+      .findFromCacheOrRefetch(
+        makeDefinitionRequest(
+          source,
+          definitionLanguage,
+          wordLanguage,
+          index,
+          word
+        )
+      )
+      .map(entries =>
+        entries.map(entry => convertToDefinition(entry, word.tag))
+      )
+  }
+
+  // Definition domain to elasticsearch domain
+  private[this] def makeDefinitionRequest(
+      source: DefinitionSource,
+      definitionLanguage: Language,
+      wordLanguage: Language,
+      index: String,
+      word: Word
+  ): ElasticsearchSearchRequest[T] = {
+    val fetcher = () => fetch(definitionLanguage, word)
+
+    ElasticsearchSearchRequest(
+      index,
+      Map(
+        "wordLanguage" -> wordLanguage.toString,
+        "definitionLanguage" -> definitionLanguage.toString,
+        "token" -> word.processedToken,
+        "source" -> source.toString
+      ),
+      fetcher,
+      maxFetchAttempts
+    )
+  }
+}

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/DefinitionFetcher.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/DefinitionFetcher.scala
@@ -9,20 +9,22 @@ import com.foreignlanguagereader.content.types.internal.word.Word
 import com.foreignlanguagereader.domain.client.common.CircuitBreakerResult
 import com.foreignlanguagereader.domain.client.elasticsearch.ElasticsearchCacheClient
 import com.foreignlanguagereader.domain.client.elasticsearch.searchstates.ElasticsearchSearchRequest
+import play.api.Logger
 import play.api.libs.json.{Reads, Writes}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.reflect.ClassTag
 
 trait DefinitionFetcher[T <: DefinitionEntry, U <: Definition] {
+  val logger: Logger = Logger(this.getClass)
+
   def fetch(
       language: Language,
       word: Word
-  ): Future[CircuitBreakerResult[List[T]]]
+  )(implicit ec: ExecutionContext): Future[CircuitBreakerResult[List[T]]]
   def convertToDefinition(entry: T, tag: PartOfSpeech): U
   implicit val reads: Reads[T]
   implicit val writes: Writes[T]
-  implicit val ec: ExecutionContext
 
   val maxFetchAttempts = 5
 
@@ -33,7 +35,7 @@ trait DefinitionFetcher[T <: DefinitionEntry, U <: Definition] {
       wordLanguage: Language,
       source: DefinitionSource,
       word: Word
-  )(implicit tag: ClassTag[T]): Future[List[U]] = {
+  )(implicit ec: ExecutionContext, tag: ClassTag[T]): Future[List[U]] = {
     elasticsearch
       .findFromCacheOrRefetch(
         makeDefinitionRequest(
@@ -44,9 +46,11 @@ trait DefinitionFetcher[T <: DefinitionEntry, U <: Definition] {
           word
         )
       )
-      .map(entries =>
+      .map(entries => {
+        logger
+          .info(s"Received results from elasticsearch for word $word: $entries")
         entries.map(entry => convertToDefinition(entry, word.tag))
-      )
+      })
   }
 
   // Definition domain to elasticsearch domain
@@ -56,7 +60,7 @@ trait DefinitionFetcher[T <: DefinitionEntry, U <: Definition] {
       wordLanguage: Language,
       index: String,
       word: Word
-  ): ElasticsearchSearchRequest[T] = {
+  )(implicit ec: ExecutionContext): ElasticsearchSearchRequest[T] = {
     val fetcher = () => fetch(definitionLanguage, word)
 
     ElasticsearchSearchRequest(

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/chinese/CEDICTFetcher.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/chinese/CEDICTFetcher.scala
@@ -13,12 +13,13 @@ import com.foreignlanguagereader.domain.client.common.{
 }
 import com.foreignlanguagereader.domain.fetcher.DefinitionFetcher
 import com.foreignlanguagereader.domain.repository.definition.Cedict
+import javax.inject.Inject
 import play.api.Logger
 import play.api.libs.json.{Reads, Writes}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class CEDICTFetcher()
+class CEDICTFetcher @Inject()
     extends DefinitionFetcher[CEDICTDefinitionEntry, ChineseDefinition] {
   override val logger: Logger = Logger(this.getClass)
 

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/chinese/CEDICTFetcher.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/chinese/CEDICTFetcher.scala
@@ -1,0 +1,43 @@
+package com.foreignlanguagereader.domain.fetcher.chinese
+
+import com.foreignlanguagereader.content.types.Language.Language
+import com.foreignlanguagereader.content.types.external.definition.DefinitionEntry
+import com.foreignlanguagereader.content.types.external.definition.cedict.CEDICTDefinitionEntry
+import com.foreignlanguagereader.content.types.internal.definition.ChineseDefinition
+import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech.PartOfSpeech
+import com.foreignlanguagereader.content.types.internal.word.Word
+import com.foreignlanguagereader.domain.client.common.{
+  CircuitBreakerAttempt,
+  CircuitBreakerNonAttempt,
+  CircuitBreakerResult
+}
+import com.foreignlanguagereader.domain.fetcher.DefinitionFetcher
+import com.foreignlanguagereader.domain.repository.definition.Cedict
+import play.api.libs.json.{Reads, Writes}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class CEDICTFetcher(override implicit val ec: ExecutionContext)
+    extends DefinitionFetcher[CEDICTDefinitionEntry, ChineseDefinition] {
+  override def fetch(
+      language: Language,
+      word: Word
+  ): Future[CircuitBreakerResult[List[CEDICTDefinitionEntry]]] =
+    Cedict.getDefinition(word) match {
+      case Some(entries) => Future.successful(CircuitBreakerAttempt(entries))
+      case None =>
+        Future.successful(
+          CircuitBreakerNonAttempt[List[CEDICTDefinitionEntry]]()
+        )
+    }
+
+  override def convertToDefinition(
+      entry: CEDICTDefinitionEntry,
+      tag: PartOfSpeech
+  ): ChineseDefinition = DefinitionEntry.buildChineseDefinition(entry, tag)
+
+  override implicit val reads: Reads[CEDICTDefinitionEntry] =
+    CEDICTDefinitionEntry.format
+  override implicit val writes: Writes[CEDICTDefinitionEntry] =
+    CEDICTDefinitionEntry.format
+}

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/chinese/WiktionaryChineseFetcher.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/chinese/WiktionaryChineseFetcher.scala
@@ -1,0 +1,45 @@
+package com.foreignlanguagereader.domain.fetcher.chinese
+
+import com.foreignlanguagereader.content.types.Language.Language
+import com.foreignlanguagereader.content.types.external.definition.DefinitionEntry
+import com.foreignlanguagereader.content.types.external.definition.wiktionary.WiktionaryDefinitionEntry
+import com.foreignlanguagereader.content.types.internal.definition.ChineseDefinition
+import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech.PartOfSpeech
+import com.foreignlanguagereader.content.types.internal.word.Word
+import com.foreignlanguagereader.domain.client.common.{
+  CircuitBreakerFailedAttempt,
+  CircuitBreakerResult
+}
+import com.foreignlanguagereader.domain.fetcher.DefinitionFetcher
+import play.api.libs.json.{Reads, Writes}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class WiktionaryChineseFetcher()(
+    override implicit val ec: ExecutionContext
+) extends DefinitionFetcher[
+      WiktionaryDefinitionEntry,
+      ChineseDefinition
+    ] {
+  override def fetch(
+      language: Language,
+      word: Word
+  ): Future[CircuitBreakerResult[List[WiktionaryDefinitionEntry]]] =
+    Future.apply(
+      CircuitBreakerFailedAttempt(
+        new NotImplementedError(
+          "Wiktionary is a elasticsearch only fetcher"
+        )
+      )
+    )
+
+  override def convertToDefinition(
+      entry: WiktionaryDefinitionEntry,
+      tag: PartOfSpeech
+  ): ChineseDefinition = DefinitionEntry.buildChineseDefinition(entry, tag)
+
+  override implicit val reads: Reads[WiktionaryDefinitionEntry] =
+    WiktionaryDefinitionEntry.format
+  override implicit val writes: Writes[WiktionaryDefinitionEntry] =
+    WiktionaryDefinitionEntry.format
+}

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/chinese/WiktionaryChineseFetcher.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/chinese/WiktionaryChineseFetcher.scala
@@ -15,15 +15,16 @@ import play.api.libs.json.{Reads, Writes}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class WiktionaryChineseFetcher()(
-    override implicit val ec: ExecutionContext
-) extends DefinitionFetcher[
+class WiktionaryChineseFetcher
+    extends DefinitionFetcher[
       WiktionaryDefinitionEntry,
       ChineseDefinition
     ] {
   override def fetch(
       language: Language,
       word: Word
+  )(implicit
+      ec: ExecutionContext
   ): Future[CircuitBreakerResult[List[WiktionaryDefinitionEntry]]] =
     Future.apply(
       CircuitBreakerFailedAttempt(

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/chinese/WiktionaryChineseFetcher.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/chinese/WiktionaryChineseFetcher.scala
@@ -11,11 +11,12 @@ import com.foreignlanguagereader.domain.client.common.{
   CircuitBreakerResult
 }
 import com.foreignlanguagereader.domain.fetcher.DefinitionFetcher
+import javax.inject.Inject
 import play.api.libs.json.{Reads, Writes}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class WiktionaryChineseFetcher
+class WiktionaryChineseFetcher @Inject()
     extends DefinitionFetcher[
       WiktionaryDefinitionEntry,
       ChineseDefinition

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/english/WebsterEnglishToSpanishFetcher.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/english/WebsterEnglishToSpanishFetcher.scala
@@ -13,15 +13,16 @@ import play.api.libs.json.{Reads, Writes}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class WebsterEnglishToSpanishFetcher(websterClient: MirriamWebsterClient)(
-    override implicit val ec: ExecutionContext
-) extends DefinitionFetcher[
+class WebsterEnglishToSpanishFetcher(websterClient: MirriamWebsterClient)
+    extends DefinitionFetcher[
       WebsterSpanishDefinitionEntry,
       EnglishDefinition
     ] {
   override def fetch(
       language: Language,
       word: Word
+  )(implicit
+      ec: ExecutionContext
   ): Future[CircuitBreakerResult[List[WebsterSpanishDefinitionEntry]]] =
     websterClient.getSpanishDefinition(word)
 

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/english/WebsterEnglishToSpanishFetcher.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/english/WebsterEnglishToSpanishFetcher.scala
@@ -9,12 +9,14 @@ import com.foreignlanguagereader.content.types.internal.word.Word
 import com.foreignlanguagereader.domain.client.MirriamWebsterClient
 import com.foreignlanguagereader.domain.client.common.CircuitBreakerResult
 import com.foreignlanguagereader.domain.fetcher.DefinitionFetcher
+import javax.inject.Inject
 import play.api.libs.json.{Reads, Writes}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class WebsterEnglishToSpanishFetcher(websterClient: MirriamWebsterClient)
-    extends DefinitionFetcher[
+class WebsterEnglishToSpanishFetcher @Inject() (
+    websterClient: MirriamWebsterClient
+) extends DefinitionFetcher[
       WebsterSpanishDefinitionEntry,
       EnglishDefinition
     ] {

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/english/WebsterEnglishToSpanishFetcher.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/english/WebsterEnglishToSpanishFetcher.scala
@@ -1,0 +1,37 @@
+package com.foreignlanguagereader.domain.fetcher.english
+
+import com.foreignlanguagereader.content.types.Language.Language
+import com.foreignlanguagereader.content.types.external.definition.DefinitionEntry
+import com.foreignlanguagereader.content.types.external.definition.webster.WebsterSpanishDefinitionEntry
+import com.foreignlanguagereader.content.types.internal.definition.EnglishDefinition
+import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech.PartOfSpeech
+import com.foreignlanguagereader.content.types.internal.word.Word
+import com.foreignlanguagereader.domain.client.MirriamWebsterClient
+import com.foreignlanguagereader.domain.client.common.CircuitBreakerResult
+import com.foreignlanguagereader.domain.fetcher.DefinitionFetcher
+import play.api.libs.json.{Reads, Writes}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class WebsterEnglishToSpanishFetcher(websterClient: MirriamWebsterClient)(
+    override implicit val ec: ExecutionContext
+) extends DefinitionFetcher[
+      WebsterSpanishDefinitionEntry,
+      EnglishDefinition
+    ] {
+  override def fetch(
+      language: Language,
+      word: Word
+  ): Future[CircuitBreakerResult[List[WebsterSpanishDefinitionEntry]]] =
+    websterClient.getSpanishDefinition(word)
+
+  override def convertToDefinition(
+      entry: WebsterSpanishDefinitionEntry,
+      tag: PartOfSpeech
+  ): EnglishDefinition = DefinitionEntry.buildEnglishDefinition(entry, tag)
+
+  override implicit val reads: Reads[WebsterSpanishDefinitionEntry] =
+    WebsterSpanishDefinitionEntry.reads
+  override implicit val writes: Writes[WebsterSpanishDefinitionEntry] =
+    WebsterSpanishDefinitionEntry.writes
+}

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/english/WebsterLearnersFetcher.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/english/WebsterLearnersFetcher.scala
@@ -9,11 +9,12 @@ import com.foreignlanguagereader.content.types.internal.word.Word
 import com.foreignlanguagereader.domain.client.MirriamWebsterClient
 import com.foreignlanguagereader.domain.client.common.CircuitBreakerResult
 import com.foreignlanguagereader.domain.fetcher.DefinitionFetcher
+import javax.inject.Inject
 import play.api.libs.json.{Reads, Writes}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class WebsterLearnersFetcher(websterClient: MirriamWebsterClient)
+class WebsterLearnersFetcher @Inject() (websterClient: MirriamWebsterClient)
     extends DefinitionFetcher[
       WebsterLearnersDefinitionEntry,
       EnglishDefinition

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/english/WebsterLearnersFetcher.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/english/WebsterLearnersFetcher.scala
@@ -13,15 +13,16 @@ import play.api.libs.json.{Reads, Writes}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class WebsterLearnersFetcher(websterClient: MirriamWebsterClient)(
-    override implicit val ec: ExecutionContext
-) extends DefinitionFetcher[
+class WebsterLearnersFetcher(websterClient: MirriamWebsterClient)
+    extends DefinitionFetcher[
       WebsterLearnersDefinitionEntry,
       EnglishDefinition
     ] {
   override def fetch(
       language: Language,
       word: Word
+  )(implicit
+      ec: ExecutionContext
   ): Future[CircuitBreakerResult[List[WebsterLearnersDefinitionEntry]]] =
     websterClient.getLearnersDefinition(word)
 

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/english/WebsterLearnersFetcher.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/english/WebsterLearnersFetcher.scala
@@ -1,0 +1,37 @@
+package com.foreignlanguagereader.domain.fetcher.english
+
+import com.foreignlanguagereader.content.types.Language.Language
+import com.foreignlanguagereader.content.types.external.definition.DefinitionEntry
+import com.foreignlanguagereader.content.types.external.definition.webster.WebsterLearnersDefinitionEntry
+import com.foreignlanguagereader.content.types.internal.definition.EnglishDefinition
+import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech.PartOfSpeech
+import com.foreignlanguagereader.content.types.internal.word.Word
+import com.foreignlanguagereader.domain.client.MirriamWebsterClient
+import com.foreignlanguagereader.domain.client.common.CircuitBreakerResult
+import com.foreignlanguagereader.domain.fetcher.DefinitionFetcher
+import play.api.libs.json.{Reads, Writes}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class WebsterLearnersFetcher(websterClient: MirriamWebsterClient)(
+    override implicit val ec: ExecutionContext
+) extends DefinitionFetcher[
+      WebsterLearnersDefinitionEntry,
+      EnglishDefinition
+    ] {
+  override def fetch(
+      language: Language,
+      word: Word
+  ): Future[CircuitBreakerResult[List[WebsterLearnersDefinitionEntry]]] =
+    websterClient.getLearnersDefinition(word)
+
+  override def convertToDefinition(
+      entry: WebsterLearnersDefinitionEntry,
+      tag: PartOfSpeech
+  ): EnglishDefinition = DefinitionEntry.buildEnglishDefinition(entry, tag)
+
+  override implicit val reads: Reads[WebsterLearnersDefinitionEntry] =
+    WebsterLearnersDefinitionEntry.reads
+  override implicit val writes: Writes[WebsterLearnersDefinitionEntry] =
+    WebsterLearnersDefinitionEntry.writes
+}

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/english/WiktionaryEnglishFetcher.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/english/WiktionaryEnglishFetcher.scala
@@ -11,11 +11,12 @@ import com.foreignlanguagereader.domain.client.common.{
   CircuitBreakerResult
 }
 import com.foreignlanguagereader.domain.fetcher.DefinitionFetcher
+import javax.inject.Inject
 import play.api.libs.json.{Reads, Writes}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class WiktionaryEnglishFetcher()
+class WiktionaryEnglishFetcher @Inject()
     extends DefinitionFetcher[
       WiktionaryDefinitionEntry,
       EnglishDefinition

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/english/WiktionaryEnglishFetcher.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/english/WiktionaryEnglishFetcher.scala
@@ -15,15 +15,16 @@ import play.api.libs.json.{Reads, Writes}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class WiktionaryEnglishFetcher()(
-    override implicit val ec: ExecutionContext
-) extends DefinitionFetcher[
+class WiktionaryEnglishFetcher()
+    extends DefinitionFetcher[
       WiktionaryDefinitionEntry,
       EnglishDefinition
     ] {
   override def fetch(
       language: Language,
       word: Word
+  )(implicit
+      ec: ExecutionContext
   ): Future[CircuitBreakerResult[List[WiktionaryDefinitionEntry]]] =
     Future.apply(
       CircuitBreakerFailedAttempt(

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/english/WiktionaryEnglishFetcher.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/english/WiktionaryEnglishFetcher.scala
@@ -1,0 +1,45 @@
+package com.foreignlanguagereader.domain.fetcher.english
+
+import com.foreignlanguagereader.content.types.Language.Language
+import com.foreignlanguagereader.content.types.external.definition.DefinitionEntry
+import com.foreignlanguagereader.content.types.external.definition.wiktionary.WiktionaryDefinitionEntry
+import com.foreignlanguagereader.content.types.internal.definition.EnglishDefinition
+import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech.PartOfSpeech
+import com.foreignlanguagereader.content.types.internal.word.Word
+import com.foreignlanguagereader.domain.client.common.{
+  CircuitBreakerFailedAttempt,
+  CircuitBreakerResult
+}
+import com.foreignlanguagereader.domain.fetcher.DefinitionFetcher
+import play.api.libs.json.{Reads, Writes}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class WiktionaryEnglishFetcher()(
+    override implicit val ec: ExecutionContext
+) extends DefinitionFetcher[
+      WiktionaryDefinitionEntry,
+      EnglishDefinition
+    ] {
+  override def fetch(
+      language: Language,
+      word: Word
+  ): Future[CircuitBreakerResult[List[WiktionaryDefinitionEntry]]] =
+    Future.apply(
+      CircuitBreakerFailedAttempt(
+        new NotImplementedError(
+          "Wiktionary is a elasticsearch only fetcher"
+        )
+      )
+    )
+
+  override def convertToDefinition(
+      entry: WiktionaryDefinitionEntry,
+      tag: PartOfSpeech
+  ): EnglishDefinition = DefinitionEntry.buildEnglishDefinition(entry, tag)
+
+  override implicit val reads: Reads[WiktionaryDefinitionEntry] =
+    WiktionaryDefinitionEntry.format
+  override implicit val writes: Writes[WiktionaryDefinitionEntry] =
+    WiktionaryDefinitionEntry.format
+}

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/spanish/WebsterSpanishToEnglishFetcher.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/spanish/WebsterSpanishToEnglishFetcher.scala
@@ -9,12 +9,14 @@ import com.foreignlanguagereader.content.types.internal.word.Word
 import com.foreignlanguagereader.domain.client.MirriamWebsterClient
 import com.foreignlanguagereader.domain.client.common.CircuitBreakerResult
 import com.foreignlanguagereader.domain.fetcher.DefinitionFetcher
+import javax.inject.Inject
 import play.api.libs.json.{Reads, Writes}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class WebsterSpanishToEnglishFetcher(websterClient: MirriamWebsterClient)
-    extends DefinitionFetcher[
+class WebsterSpanishToEnglishFetcher @Inject() (
+    websterClient: MirriamWebsterClient
+) extends DefinitionFetcher[
       WebsterSpanishDefinitionEntry,
       SpanishDefinition
     ] {

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/spanish/WebsterSpanishToEnglishFetcher.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/spanish/WebsterSpanishToEnglishFetcher.scala
@@ -1,0 +1,37 @@
+package com.foreignlanguagereader.domain.fetcher.spanish
+
+import com.foreignlanguagereader.content.types.Language.Language
+import com.foreignlanguagereader.content.types.external.definition.DefinitionEntry
+import com.foreignlanguagereader.content.types.external.definition.webster.WebsterSpanishDefinitionEntry
+import com.foreignlanguagereader.content.types.internal.definition.SpanishDefinition
+import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech.PartOfSpeech
+import com.foreignlanguagereader.content.types.internal.word.Word
+import com.foreignlanguagereader.domain.client.MirriamWebsterClient
+import com.foreignlanguagereader.domain.client.common.CircuitBreakerResult
+import com.foreignlanguagereader.domain.fetcher.DefinitionFetcher
+import play.api.libs.json.{Reads, Writes}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class WebsterSpanishToEnglishFetcher(websterClient: MirriamWebsterClient)(
+    override implicit val ec: ExecutionContext
+) extends DefinitionFetcher[
+      WebsterSpanishDefinitionEntry,
+      SpanishDefinition
+    ] {
+  override def fetch(
+      language: Language,
+      word: Word
+  ): Future[CircuitBreakerResult[List[WebsterSpanishDefinitionEntry]]] =
+    websterClient.getSpanishDefinition(word)
+
+  override def convertToDefinition(
+      entry: WebsterSpanishDefinitionEntry,
+      tag: PartOfSpeech
+  ): SpanishDefinition = DefinitionEntry.buildSpanishDefinition(entry, tag)
+
+  override implicit val reads: Reads[WebsterSpanishDefinitionEntry] =
+    WebsterSpanishDefinitionEntry.reads
+  override implicit val writes: Writes[WebsterSpanishDefinitionEntry] =
+    WebsterSpanishDefinitionEntry.writes
+}

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/spanish/WebsterSpanishToEnglishFetcher.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/spanish/WebsterSpanishToEnglishFetcher.scala
@@ -13,15 +13,16 @@ import play.api.libs.json.{Reads, Writes}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class WebsterSpanishToEnglishFetcher(websterClient: MirriamWebsterClient)(
-    override implicit val ec: ExecutionContext
-) extends DefinitionFetcher[
+class WebsterSpanishToEnglishFetcher(websterClient: MirriamWebsterClient)
+    extends DefinitionFetcher[
       WebsterSpanishDefinitionEntry,
       SpanishDefinition
     ] {
   override def fetch(
       language: Language,
       word: Word
+  )(implicit
+      ec: ExecutionContext
   ): Future[CircuitBreakerResult[List[WebsterSpanishDefinitionEntry]]] =
     websterClient.getSpanishDefinition(word)
 

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/spanish/WiktionarySpanishFetcher.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/spanish/WiktionarySpanishFetcher.scala
@@ -11,11 +11,12 @@ import com.foreignlanguagereader.domain.client.common.{
   CircuitBreakerResult
 }
 import com.foreignlanguagereader.domain.fetcher.DefinitionFetcher
+import javax.inject.Inject
 import play.api.libs.json.{Reads, Writes}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class WiktionarySpanishFetcher
+class WiktionarySpanishFetcher @Inject()
     extends DefinitionFetcher[
       WiktionaryDefinitionEntry,
       SpanishDefinition

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/spanish/WiktionarySpanishFetcher.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/spanish/WiktionarySpanishFetcher.scala
@@ -1,0 +1,45 @@
+package com.foreignlanguagereader.domain.fetcher.spanish
+
+import com.foreignlanguagereader.content.types.Language.Language
+import com.foreignlanguagereader.content.types.external.definition.DefinitionEntry
+import com.foreignlanguagereader.content.types.external.definition.wiktionary.WiktionaryDefinitionEntry
+import com.foreignlanguagereader.content.types.internal.definition.SpanishDefinition
+import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech.PartOfSpeech
+import com.foreignlanguagereader.content.types.internal.word.Word
+import com.foreignlanguagereader.domain.client.common.{
+  CircuitBreakerFailedAttempt,
+  CircuitBreakerResult
+}
+import com.foreignlanguagereader.domain.fetcher.DefinitionFetcher
+import play.api.libs.json.{Reads, Writes}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class WiktionarySpanishFetcher()(
+    override implicit val ec: ExecutionContext
+) extends DefinitionFetcher[
+      WiktionaryDefinitionEntry,
+      SpanishDefinition
+    ] {
+  override def fetch(
+      language: Language,
+      word: Word
+  ): Future[CircuitBreakerResult[List[WiktionaryDefinitionEntry]]] =
+    Future.apply(
+      CircuitBreakerFailedAttempt(
+        new NotImplementedError(
+          "Wiktionary is a elasticsearch only fetcher"
+        )
+      )
+    )
+
+  override def convertToDefinition(
+      entry: WiktionaryDefinitionEntry,
+      tag: PartOfSpeech
+  ): SpanishDefinition = DefinitionEntry.buildSpanishDefinition(entry, tag)
+
+  override implicit val reads: Reads[WiktionaryDefinitionEntry] =
+    WiktionaryDefinitionEntry.format
+  override implicit val writes: Writes[WiktionaryDefinitionEntry] =
+    WiktionaryDefinitionEntry.format
+}

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/spanish/WiktionarySpanishFetcher.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/spanish/WiktionarySpanishFetcher.scala
@@ -15,15 +15,16 @@ import play.api.libs.json.{Reads, Writes}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class WiktionarySpanishFetcher()(
-    override implicit val ec: ExecutionContext
-) extends DefinitionFetcher[
+class WiktionarySpanishFetcher
+    extends DefinitionFetcher[
       WiktionaryDefinitionEntry,
       SpanishDefinition
     ] {
   override def fetch(
       language: Language,
       word: Word
+  )(implicit
+      ec: ExecutionContext
   ): Future[CircuitBreakerResult[List[WiktionaryDefinitionEntry]]] =
     Future.apply(
       CircuitBreakerFailedAttempt(

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/service/DocumentService.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/service/DocumentService.scala
@@ -52,7 +52,6 @@ class DocumentService @Inject() (
   ): Future[Set[Word]] = {
     googleCloudClient
       .getWordsForDocument(language, document)
-      .value
       .map {
         case CircuitBreakerAttempt(result)  => result
         case CircuitBreakerNonAttempt()     => Set[Word]()

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/service/definition/ChineseDefinitionService.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/service/definition/ChineseDefinitionService.scala
@@ -13,7 +13,10 @@ import com.foreignlanguagereader.content.types.internal.definition.{
 import com.foreignlanguagereader.content.types.internal.word.Word
 import com.foreignlanguagereader.domain.client.elasticsearch.ElasticsearchCacheClient
 import com.foreignlanguagereader.domain.fetcher.DefinitionFetcher
-import com.foreignlanguagereader.domain.fetcher.chinese.CEDICTFetcher
+import com.foreignlanguagereader.domain.fetcher.chinese.{
+  CEDICTFetcher,
+  WiktionaryChineseFetcher
+}
 import com.github.houbb.opencc4j.util.ZhConverterUtil
 import javax.inject.Inject
 import play.api.{Configuration, Logger}
@@ -33,14 +36,19 @@ class ChineseDefinitionService @Inject() (
   override val logger: Logger = Logger(this.getClass)
 
   override val wordLanguage: Language = Language.CHINESE
-  override val sources: List[DefinitionSource] = List(DefinitionSource.CEDICT)
+  override val sources: List[DefinitionSource] =
+    List(DefinitionSource.CEDICT, DefinitionSource.WIKTIONARY)
 
   override val definitionFetchers: Map[
     (DefinitionSource, Language),
     DefinitionFetcher[_, ChineseDefinition]
   ] =
     Map(
-      (DefinitionSource.CEDICT, Language.ENGLISH) -> new CEDICTFetcher()
+      (DefinitionSource.CEDICT, Language.ENGLISH) -> new CEDICTFetcher(),
+      (
+        DefinitionSource.WIKTIONARY,
+        Language.ENGLISH
+      ) -> new WiktionaryChineseFetcher()
     )
 
   // Convert everything to traditional

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/service/definition/ChineseDefinitionService.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/service/definition/ChineseDefinitionService.scala
@@ -31,6 +31,8 @@ import scala.concurrent.ExecutionContext
 class ChineseDefinitionService @Inject() (
     val elasticsearch: ElasticsearchCacheClient,
     override val config: Configuration,
+    cedictFetcher: CEDICTFetcher,
+    wiktionaryChineseFetcher: WiktionaryChineseFetcher,
     implicit val ec: ExecutionContext
 ) extends LanguageDefinitionService[ChineseDefinition] {
   override val logger: Logger = Logger(this.getClass)
@@ -44,15 +46,15 @@ class ChineseDefinitionService @Inject() (
     DefinitionFetcher[_, ChineseDefinition]
   ] =
     Map(
-      (DefinitionSource.CEDICT, Language.ENGLISH) -> new CEDICTFetcher(),
+      (DefinitionSource.CEDICT, Language.ENGLISH) -> cedictFetcher,
       (
         DefinitionSource.WIKTIONARY,
         Language.ENGLISH
-      ) -> new WiktionaryChineseFetcher(),
+      ) -> wiktionaryChineseFetcher,
       (
         DefinitionSource.WIKTIONARY,
         Language.CHINESE
-      ) -> new WiktionaryChineseFetcher()
+      ) -> wiktionaryChineseFetcher
     )
 
   // Convert everything to traditional

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/service/definition/ChineseDefinitionService.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/service/definition/ChineseDefinitionService.scala
@@ -48,6 +48,10 @@ class ChineseDefinitionService @Inject() (
       (
         DefinitionSource.WIKTIONARY,
         Language.ENGLISH
+      ) -> new WiktionaryChineseFetcher(),
+      (
+        DefinitionSource.WIKTIONARY,
+        Language.CHINESE
       ) -> new WiktionaryChineseFetcher()
     )
 
@@ -69,8 +73,12 @@ class ChineseDefinitionService @Inject() (
       definitions: Map[DefinitionSource, List[ChineseDefinition]]
   ): List[ChineseDefinition] = {
     definitionLanguage match {
-      case Language.ENGLISH => enrichEnglishDefinitions(word, definitions)
-      case _                => super.enrichDefinitions(definitionLanguage, word, definitions)
+      case Language.ENGLISH =>
+        logger.info("Enriching Chinese definitions in English")
+        enrichEnglishDefinitions(word, definitions)
+      case _ =>
+        logger.info(s"Not enriching Chinese definitions in $definitionLanguage")
+        super.enrichDefinitions(definitionLanguage, word, definitions)
     }
   }
 

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/service/definition/EnglishDefinitionService.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/service/definition/EnglishDefinitionService.scala
@@ -7,7 +7,6 @@ import com.foreignlanguagereader.content.types.internal.definition.{
   DefinitionSource,
   EnglishDefinition
 }
-import com.foreignlanguagereader.domain.client.MirriamWebsterClient
 import com.foreignlanguagereader.domain.client.elasticsearch.ElasticsearchCacheClient
 import com.foreignlanguagereader.domain.fetcher.DefinitionFetcher
 import com.foreignlanguagereader.domain.fetcher.english.{
@@ -21,7 +20,8 @@ import scala.concurrent.ExecutionContext
 
 class EnglishDefinitionService @Inject() (
     val elasticsearch: ElasticsearchCacheClient,
-    val websterClient: MirriamWebsterClient,
+    val websterLearnersFetcher: WebsterLearnersFetcher,
+    val websterEnglishToSpanishFetcher: WebsterEnglishToSpanishFetcher,
     override val config: Configuration,
     implicit val ec: ExecutionContext
 ) extends LanguageDefinitionService[EnglishDefinition] {
@@ -42,10 +42,10 @@ class EnglishDefinitionService @Inject() (
       (
         DefinitionSource.MIRRIAM_WEBSTER_LEARNERS,
         Language.ENGLISH
-      ) -> new WebsterLearnersFetcher(websterClient),
+      ) -> websterLearnersFetcher,
       (
         DefinitionSource.MIRRIAM_WEBSTER_SPANISH,
         Language.SPANISH
-      ) -> new WebsterEnglishToSpanishFetcher(websterClient)
+      ) -> websterEnglishToSpanishFetcher
     )
 }

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/service/definition/LanguageDefinitionService.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/service/definition/LanguageDefinitionService.scala
@@ -81,9 +81,17 @@ trait LanguageDefinitionService[T <: Definition] {
         }
       )
       .map(definitions =>
-        if (definitions.nonEmpty)
+        if (definitions.nonEmpty) {
+          logger.info(
+            s"Enriching definitions in $definitionLanguage for word $word"
+          )
           enrichDefinitions(definitionLanguage, word, definitions)
-        else List()
+        } else {
+          logger.info(
+            s"Not enriching definitions in $definitionLanguage for word $word because no results were found"
+          )
+          List()
+        }
       )
   }
 

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/service/definition/LanguageDefinitionService.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/service/definition/LanguageDefinitionService.scala
@@ -1,21 +1,16 @@
 package com.foreignlanguagereader.domain.service.definition
 
-import cats.data.Nested
-import cats.implicits._
-import com.foreignlanguagereader.content.types.Language
 import com.foreignlanguagereader.content.types.Language.Language
+import com.foreignlanguagereader.content.types.external.definition.DefinitionEntry
+import com.foreignlanguagereader.content.types.internal.definition.Definition
 import com.foreignlanguagereader.content.types.internal.definition.DefinitionSource.DefinitionSource
-import com.foreignlanguagereader.content.types.internal.definition.{
-  Definition,
-  DefinitionSource
-}
 import com.foreignlanguagereader.content.types.internal.word.Word
 import com.foreignlanguagereader.domain.client.common.{
-  CircuitBreakerNonAttempt,
+  CircuitBreakerFailedAttempt,
   CircuitBreakerResult
 }
 import com.foreignlanguagereader.domain.client.elasticsearch.ElasticsearchCacheClient
-import com.foreignlanguagereader.domain.client.elasticsearch.searchstates.ElasticsearchSearchRequest
+import com.foreignlanguagereader.domain.fetcher.DefinitionFetcher
 import play.api.{Configuration, Logger}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -40,10 +35,10 @@ import scala.concurrent.{ExecutionContext, Future}
  * ec: A thread pool to use. Since none of these methods are blocking, any pool is fine.
  * elasticsearch: An ElasticsearchClient for use in caching and getting file sources
  */
-trait LanguageDefinitionService {
+trait LanguageDefinitionService[T <: Definition] {
   // These are required fields for implementers
   implicit val ec: ExecutionContext
-  implicit val config: Configuration
+  val config: Configuration
   val logger: Logger = Logger(this.getClass)
   val elasticsearch: ElasticsearchCacheClient
   val wordLanguage: Language
@@ -56,35 +51,29 @@ trait LanguageDefinitionService {
   def preprocessWordForRequest(word: Word): List[Word] = List(word)
 
   // Functions that can fetch definitions from web sources should be registered here.
-  val definitionFetchers: Map[
-    (DefinitionSource, Language),
-    (Language, Word) => Nested[Future, CircuitBreakerResult, List[Definition]]
-  ] =
-    Map(
-      (
-        DefinitionSource.WIKTIONARY,
-        Language.ENGLISH
-      ) -> elasticsearchDefinitionClient
-    )
+  val definitionFetchers
+      : Map[(DefinitionSource, Language), DefinitionFetcher[_, T]] = Map()
   val maxFetchAttempts = 5
 
   // Define logic to combine definition sources here. If there is only one source, this just returns it.
   def enrichDefinitions(
       definitionLanguage: Language,
       word: Word,
-      definitions: Map[DefinitionSource, List[Definition]]
-  ): List[Definition] = definitions.values.flatten.toList
+      definitions: Map[DefinitionSource, List[T]]
+  ): List[T] = definitions.values.flatten.toList
 
   // This is the main method that consumers will call
   def getDefinitions(
       definitionLanguage: Language,
       word: Word
-  ): Future[List[Definition]] = {
-    preprocessWordForRequest(word)
-    // Trigger all requests asynchronously and block for all to complete
-      .traverse(token => fetchDefinitions(sources, definitionLanguage, token))
-      // Merge definitions for each lookup term
-      .map(_.combineAll)
+  ): Future[List[T]] = {
+    Future
+      .traverse(sources)(source =>
+        getDefinitionsForSingleSource(definitionLanguage, source, word).map(
+          results => source -> results
+        )
+      )
+      .map(_.toMap)
       // Remove empty sources
       .map(p =>
         p.collect {
@@ -100,59 +89,51 @@ trait LanguageDefinitionService {
 
   // Below here is trait behavior, implementers need not read further
 
-  // Use this for definitions not backed by a rest API: eg loaded using spark
-  def elasticsearchDefinitionClient: (
-      Language,
-      Word
-  ) => Nested[Future, CircuitBreakerResult, List[Definition]] =
-    (_, word: Word) => Nested(Future.apply(CircuitBreakerNonAttempt()))
-
-  private[this] def fetchDefinitions(
-      sources: List[DefinitionSource],
+  private[this] def getDefinitionsForSingleSource(
       definitionLanguage: Language,
+      source: DefinitionSource,
       word: Word
-  ): Future[Map[DefinitionSource, List[Definition]]] = {
-    elasticsearch
-      .findFromCacheOrRefetch[Definition](
-        sources
-          .map(source =>
-            makeDefinitionRequest(source, definitionLanguage, word)
-          )
+  ): Future[List[T]] = {
+    Future
+      .traverse(preprocessWordForRequest(word))(token =>
+        getDefinitionsForToken(definitionLanguage, source, token)
       )
-      .map(results => sources.zip(results).toMap)
+      .map(_.flatten)
   }
+
+  private[this] def getDefinitionsForToken(
+      definitionLanguage: Language,
+      source: DefinitionSource,
+      word: Word
+  ): Future[List[T]] =
+    definitionFetchers.get((source, definitionLanguage)) match {
+      case None => Future.successful(List[T]())
+      case Some(fetcher) =>
+        fetcher
+          .fetchDefinitions(
+            elasticsearch,
+            getIndex,
+            definitionLanguage,
+            wordLanguage,
+            source,
+            word
+          )
+    }
+
+  // Use this for definitions not backed by a rest API: eg loaded using spark
+  def elasticsearchDefinitionClient[U <: DefinitionEntry](
+      language: Language,
+      word: Word
+  ): Future[CircuitBreakerResult[List[U]]] =
+    Future.apply(
+      CircuitBreakerFailedAttempt(
+        new NotImplementedError(
+          s"Fetcher not implemented for language: $language, failed to fetch $word"
+        )
+      )
+    )
 
   def getIndex: String = {
     s"definitions-${config.get[String]("environment")}"
-  }
-
-  // Definition domain to elasticsearch domain
-  private[this] def makeDefinitionRequest(
-      source: DefinitionSource,
-      definitionLanguage: Language,
-      word: Word
-  ): ElasticsearchSearchRequest[Definition] = {
-    val fetcher: () => Future[CircuitBreakerResult[List[Definition]]] =
-      definitionFetchers.get(source, definitionLanguage) match {
-        case Some(fetcher) =>
-          () => fetcher(definitionLanguage, word).value
-        case None =>
-          logger.error(
-            s"Failed to search in $wordLanguage for $word because $source is not implemented for definitions in $definitionLanguage"
-          )
-          () => CircuitBreakerNonAttempt[List[Definition]]().pure[Future]
-      }
-
-    ElasticsearchSearchRequest(
-      getIndex,
-      Map(
-        "wordLanguage" -> wordLanguage.toString,
-        "definitionLanguage" -> definitionLanguage.toString,
-        "token" -> word.processedToken,
-        "source" -> source.toString
-      ),
-      fetcher,
-      maxFetchAttempts
-    )
   }
 }

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/service/definition/SpanishDefinitionService.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/service/definition/SpanishDefinitionService.scala
@@ -1,58 +1,39 @@
 package com.foreignlanguagereader.domain.service.definition
 
-import cats.data.Nested
-import com.foreignlanguagereader.domain.client.common.{
-  CircuitBreakerNonAttempt,
-  CircuitBreakerResult
-}
-import com.foreignlanguagereader.domain.client.elasticsearch.ElasticsearchCacheClient
-import com.foreignlanguagereader.domain.client.MirriamWebsterClient
 import com.foreignlanguagereader.content.types.Language
-import com.foreignlanguagereader.content.types.internal.word.Word
-import Language.Language
-import com.foreignlanguagereader.content.types.internal.definition.{
-  Definition,
-  DefinitionSource
-}
+import com.foreignlanguagereader.content.types.Language.Language
 import com.foreignlanguagereader.content.types.internal.definition.DefinitionSource.DefinitionSource
+import com.foreignlanguagereader.content.types.internal.definition.{
+  DefinitionSource,
+  SpanishDefinition
+}
+import com.foreignlanguagereader.domain.client.MirriamWebsterClient
+import com.foreignlanguagereader.domain.client.elasticsearch.ElasticsearchCacheClient
+import com.foreignlanguagereader.domain.fetcher.DefinitionFetcher
+import com.foreignlanguagereader.domain.fetcher.spanish.WebsterSpanishToEnglishFetcher
 import javax.inject.Inject
 import play.api.Configuration
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 class SpanishDefinitionService @Inject() (
     val elasticsearch: ElasticsearchCacheClient,
     val websterClient: MirriamWebsterClient,
     override val config: Configuration,
     implicit val ec: ExecutionContext
-) extends LanguageDefinitionService {
+) extends LanguageDefinitionService[SpanishDefinition] {
   override val wordLanguage: Language = Language.SPANISH
   override val sources: List[DefinitionSource] =
     List(DefinitionSource.MIRRIAM_WEBSTER_SPANISH, DefinitionSource.WIKTIONARY)
 
-  def websterFetcher: (
-      Language,
-      Word
-  ) => Nested[Future, CircuitBreakerResult, List[Definition]] =
-    (language: Language, word: Word) =>
-      language match {
-        case Language.ENGLISH =>
-          Nested(websterClient.getSpanishDefinition(word).value)
-        case _ => Nested(Future.successful(CircuitBreakerNonAttempt()))
-      }
-
   override val definitionFetchers: Map[
     (DefinitionSource, Language),
-    (Language, Word) => Nested[Future, CircuitBreakerResult, List[Definition]]
+    DefinitionFetcher[_, SpanishDefinition]
   ] = Map(
     (
       DefinitionSource.MIRRIAM_WEBSTER_SPANISH,
       Language.ENGLISH
-    ) -> websterFetcher,
-    (
-      DefinitionSource.WIKTIONARY,
-      Language.ENGLISH
-    ) -> elasticsearchDefinitionClient
+    ) -> new WebsterSpanishToEnglishFetcher(websterClient)
   )
 
 }

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/service/definition/SpanishDefinitionService.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/service/definition/SpanishDefinitionService.scala
@@ -7,7 +7,6 @@ import com.foreignlanguagereader.content.types.internal.definition.{
   DefinitionSource,
   SpanishDefinition
 }
-import com.foreignlanguagereader.domain.client.MirriamWebsterClient
 import com.foreignlanguagereader.domain.client.elasticsearch.ElasticsearchCacheClient
 import com.foreignlanguagereader.domain.fetcher.DefinitionFetcher
 import com.foreignlanguagereader.domain.fetcher.spanish.WebsterSpanishToEnglishFetcher
@@ -18,7 +17,7 @@ import scala.concurrent.ExecutionContext
 
 class SpanishDefinitionService @Inject() (
     val elasticsearch: ElasticsearchCacheClient,
-    val websterClient: MirriamWebsterClient,
+    val websterSpanishToEnglishFetcher: WebsterSpanishToEnglishFetcher,
     override val config: Configuration,
     implicit val ec: ExecutionContext
 ) extends LanguageDefinitionService[SpanishDefinition] {
@@ -33,7 +32,7 @@ class SpanishDefinitionService @Inject() (
     (
       DefinitionSource.MIRRIAM_WEBSTER_SPANISH,
       Language.ENGLISH
-    ) -> new WebsterSpanishToEnglishFetcher(websterClient)
+    ) -> websterSpanishToEnglishFetcher
   )
 
 }

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/client/common/CircuitbreakerTest.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/client/common/CircuitbreakerTest.scala
@@ -48,7 +48,6 @@ class CircuitbreakerTest extends AsyncFunSpec with MockitoSugar {
     it("returns the results of successful calls") {
       closedBreaker
         .withBreaker("Don't log")(Future.apply("testString"))
-        .value
         .map {
           case CircuitBreakerAttempt("testString") => succeed
           case _                                   => fail("This is the wrong result")
@@ -61,7 +60,6 @@ class CircuitbreakerTest extends AsyncFunSpec with MockitoSugar {
           Future
             .apply(throw new IllegalArgumentException("Something went wrong"))
         )
-        .value
         .map {
           case CircuitBreakerFailedAttempt(e) =>
             assert(e.getMessage == "Something went wrong")
@@ -84,7 +82,6 @@ class CircuitbreakerTest extends AsyncFunSpec with MockitoSugar {
             Future
               .apply(throw new IllegalArgumentException("Something went wrong"))
           )
-          .value
           .map {
             case CircuitBreakerFailedAttempt(e) =>
               assert(e.getMessage == "Something went wrong")
@@ -107,7 +104,6 @@ class CircuitbreakerTest extends AsyncFunSpec with MockitoSugar {
             Future
               .apply(throw new IllegalStateException("Something went wrong"))
           )
-          .value
           .map {
             case CircuitBreakerFailedAttempt(e) =>
               assert(e.getMessage == "Something went wrong")
@@ -133,7 +129,6 @@ class CircuitbreakerTest extends AsyncFunSpec with MockitoSugar {
             Future
               .apply(None)
           )
-          .value
           .map {
             case CircuitBreakerAttempt(None) =>
               assert(almostOpenBreaker.health() === ReadinessStatus.DOWN)
@@ -156,7 +151,6 @@ class CircuitbreakerTest extends AsyncFunSpec with MockitoSugar {
             Future
               .apply(Some("testString"))
           )
-          .value
           .map {
             case CircuitBreakerAttempt(Some("testString")) =>
               assert(almostOpenBreaker.health() === ReadinessStatus.UP)
@@ -185,7 +179,6 @@ class CircuitbreakerTest extends AsyncFunSpec with MockitoSugar {
         .withBreaker[String]("log message")(
           Future(fail("this should not have been evaluated"))
         )
-        .value
         .map {
           case CircuitBreakerNonAttempt() => succeed
           case _                          => fail("This is the wrong result")

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchCacheClientIntegrationTest.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchCacheClientIntegrationTest.scala
@@ -53,7 +53,6 @@ class ElasticsearchCacheClientIntegrationTest
 
       client
         .index(indexRequest)
-        .value
         .flatMap {
           case CircuitBreakerNonAttempt() =>
             fail("Indexing failed because circuit breaker was closed")
@@ -62,7 +61,7 @@ class ElasticsearchCacheClientIntegrationTest
           case CircuitBreakerAttempt(_) =>
             // Give elasticsearch five seconds to finish indexing before we search
             Thread.sleep(5000)
-            client.search[LookupAttempt](searchRequest).value.map {
+            client.search[LookupAttempt](searchRequest).map {
               case CircuitBreakerNonAttempt() =>
                 fail("Searching failed because circuit breaker was closed")
               case CircuitBreakerFailedAttempt(e) =>

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchCacheClientTest.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchCacheClientTest.scala
@@ -1,12 +1,11 @@
 package com.foreignlanguagereader.domain.client.elasticsearch
 
-import cats.data.Nested
 import cats.implicits._
 import com.foreignlanguagereader.content.types.Language
 import com.foreignlanguagereader.content.types.internal.definition.{
   Definition,
   DefinitionSource,
-  GenericDefinition
+  EnglishDefinition
 }
 import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech
 import com.foreignlanguagereader.domain.client.common.{
@@ -25,7 +24,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.{Mockito, MockitoSugar}
 import org.scalatest.FutureOutcome
 import org.scalatest.funspec.AsyncFunSpec
-import play.api.libs.json.Reads
+import play.api.libs.json.{Json, Reads, Writes}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -34,7 +33,7 @@ class ElasticsearchCacheClientTest extends AsyncFunSpec with MockitoSugar {
   val fields: Map[String, String] =
     Map("field1" -> "value1", "field2" -> "value2", "field3" -> "value3")
 
-  val fetchedDefinition: GenericDefinition = GenericDefinition(
+  val fetchedDefinition: EnglishDefinition = EnglishDefinition(
     List("refetched"),
     "ipa",
     PartOfSpeech.NOUN,
@@ -50,6 +49,10 @@ class ElasticsearchCacheClientTest extends AsyncFunSpec with MockitoSugar {
   val ec: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
   val cacheClient = new ElasticsearchCacheClient(baseClient, queue, ec)
 
+  implicit val reads: Reads[EnglishDefinition] = Json.reads[EnglishDefinition]
+  implicit val writes: Writes[EnglishDefinition] =
+    Json.writes[EnglishDefinition]
+
   val dummyMultisearchResponse = new MultiSearchResponse(Array(), 2L)
 
   override def withFixture(test: NoArgAsyncTest): FutureOutcome = {
@@ -59,23 +62,23 @@ class ElasticsearchCacheClientTest extends AsyncFunSpec with MockitoSugar {
   }
 
   def makeDoubleSearchResponse(
-      definitions: Seq[Definition],
+      definitions: Seq[EnglishDefinition],
       attempts: LookupAttempt
-  ): Nested[Future, CircuitBreakerResult, Option[
-    (Map[String, Definition], Map[String, LookupAttempt])
-  ]] = {
+  ): Future[CircuitBreakerResult[Option[
+    (Map[String, EnglishDefinition], Map[String, LookupAttempt])
+  ]]] = {
     val defs = definitions.map(d => d.token -> d).toMap
     val attempt = Map("dummyId" -> attempts)
-    Nested(Future.apply(CircuitBreakerAttempt(Some((defs, attempt)))))
+    Future.apply(CircuitBreakerAttempt(Some((defs, attempt))))
   }
 
   describe("an elasticsearch caching client") {
     it("can fetch results from a cache") {
       when(
-        baseClient.doubleSearch[Definition, LookupAttempt](
+        baseClient.doubleSearch[EnglishDefinition, LookupAttempt](
           any(classOf[MultiSearchRequest])
         )(
-          any(classOf[Reads[Definition]]),
+          any(classOf[Reads[EnglishDefinition]]),
           any(classOf[Reads[LookupAttempt]])
         )
       ).thenReturn(
@@ -86,32 +89,29 @@ class ElasticsearchCacheClientTest extends AsyncFunSpec with MockitoSugar {
       )
 
       cacheClient
-        .findFromCacheOrRefetch[Definition](
-          List(
-            ElasticsearchSearchRequest(
-              "definitions",
-              Map(),
-              () =>
-                throw new IllegalStateException("Fetcher shouldn't be called"),
-              5
-            )
+        .findFromCacheOrRefetch[EnglishDefinition](
+          ElasticsearchSearchRequest(
+            "definitions",
+            Map(),
+            () =>
+              throw new IllegalStateException("Fetcher shouldn't be called"),
+            5
           )
         )
         .map(results => {
           verify(queue, never)
             .addInsertsToQueue(any(classOf[Seq[ElasticsearchCacheRequest]]))
 
-          val result = results.head
-          assert(result.contains(fetchedDefinition))
+          assert(results.contains(fetchedDefinition))
         })
     }
 
     it("can handle cache misses") {
       when(
-        baseClient.doubleSearch[Definition, LookupAttempt](
+        baseClient.doubleSearch[EnglishDefinition, LookupAttempt](
           any(classOf[MultiSearchRequest])
         )(
-          any(classOf[Reads[Definition]]),
+          any(classOf[Reads[EnglishDefinition]]),
           any(classOf[Reads[LookupAttempt]])
         )
       ).thenReturn(
@@ -122,8 +122,43 @@ class ElasticsearchCacheClientTest extends AsyncFunSpec with MockitoSugar {
       )
 
       cacheClient
-        .findFromCacheOrRefetch[Definition](
-          List(
+        .findFromCacheOrRefetch[EnglishDefinition](
+          ElasticsearchSearchRequest(
+            "definitions",
+            Map(),
+            () =>
+              Future
+                .successful(CircuitBreakerAttempt(List(fetchedDefinition))),
+            5
+          )
+        )
+        .map(results => {
+          verify(queue)
+            .addInsertsToQueue(any(classOf[Seq[ElasticsearchCacheRequest]]))
+
+          assert(results.contains(fetchedDefinition))
+        })
+    }
+
+    describe("gracefully handles failures") {
+      it("can handle failures when searching from elasticsearch") {
+        when(
+          baseClient.doubleSearch[EnglishDefinition, LookupAttempt](
+            any(classOf[MultiSearchRequest])
+          )(
+            any(classOf[Reads[EnglishDefinition]]),
+            any(classOf[Reads[LookupAttempt]])
+          )
+        ).thenReturn(
+          Future.apply(
+            CircuitBreakerFailedAttempt(
+              new IllegalStateException("Uh oh")
+            )
+          )
+        )
+
+        cacheClient
+          .findFromCacheOrRefetch[EnglishDefinition](
             ElasticsearchSearchRequest(
               "definitions",
               Map(),
@@ -133,54 +168,11 @@ class ElasticsearchCacheClientTest extends AsyncFunSpec with MockitoSugar {
               5
             )
           )
-        )
-        .map(results => {
-          verify(queue)
-            .addInsertsToQueue(any(classOf[Seq[ElasticsearchCacheRequest]]))
-
-          val result = results.head
-          assert(result.contains(fetchedDefinition))
-        })
-    }
-
-    describe("gracefully handles failures") {
-      it("can handle failures when searching from elasticsearch") {
-        when(
-          baseClient.doubleSearch[Definition, LookupAttempt](
-            any(classOf[MultiSearchRequest])
-          )(
-            any(classOf[Reads[Definition]]),
-            any(classOf[Reads[LookupAttempt]])
-          )
-        ).thenReturn(
-          Nested(
-            Future.apply(
-              CircuitBreakerFailedAttempt(
-                new IllegalStateException("Uh oh")
-              )
-            )
-          )
-        )
-
-        cacheClient
-          .findFromCacheOrRefetch[Definition](
-            List(
-              ElasticsearchSearchRequest(
-                "definitions",
-                Map(),
-                () =>
-                  Future
-                    .successful(CircuitBreakerAttempt(List(fetchedDefinition))),
-                5
-              )
-            )
-          )
           .map(results => {
             verify(queue, never)
               .addInsertsToQueue(any(classOf[Seq[ElasticsearchCacheRequest]]))
 
-            val result = results.head
-            assert(result.contains(fetchedDefinition))
+            assert(results.contains(fetchedDefinition))
           })
       }
     }
@@ -208,7 +200,7 @@ class ElasticsearchCacheClientTest extends AsyncFunSpec with MockitoSugar {
         when(
           baseClient.bulk(any(classOf[BulkRequest]))
         ).thenReturn(
-          Nested(Future.successful(CircuitBreakerAttempt(mock[BulkResponse])))
+          Future.successful(CircuitBreakerAttempt(mock[BulkResponse]))
         )
 
         cacheClient
@@ -225,11 +217,9 @@ class ElasticsearchCacheClientTest extends AsyncFunSpec with MockitoSugar {
             any(classOf[BulkRequest])
           )
         ).thenReturn(
-          Nested(
-            Future.apply(
-              CircuitBreakerFailedAttempt(
-                new IllegalStateException("Please try again")
-              )
+          Future.apply(
+            CircuitBreakerFailedAttempt(
+              new IllegalStateException("Please try again")
             )
           )
         )

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/client/elasticsearch/searchstates/ElasticsearchResponseTest.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/client/elasticsearch/searchstates/ElasticsearchResponseTest.scala
@@ -4,7 +4,7 @@ import com.foreignlanguagereader.content.types.Language
 import com.foreignlanguagereader.content.types.internal.definition.{
   Definition,
   DefinitionSource,
-  GenericDefinition
+  EnglishDefinition
 }
 import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech
 import com.foreignlanguagereader.domain.client.common.{
@@ -22,7 +22,7 @@ class ElasticsearchResponseTest extends AsyncFunSpec with MockitoSugar {
   val index: String = "definition"
   val fields: Map[String, String] =
     Map("field1" -> "value1", "field2" -> "value2", "field3" -> "value3")
-  val fetchedDefinition: GenericDefinition = GenericDefinition(
+  val fetchedDefinition: EnglishDefinition = EnglishDefinition(
     List("refetched"),
     "ipa",
     PartOfSpeech.NOUN,

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/client/elasticsearch/searchstates/ElasticsearchSearchResultTest.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/client/elasticsearch/searchstates/ElasticsearchSearchResultTest.scala
@@ -5,13 +5,14 @@ import com.foreignlanguagereader.content.types.internal.definition.{
   ChineseDefinition,
   Definition,
   DefinitionSource,
-  GenericDefinition
+  EnglishDefinition
 }
 import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech
 import com.foreignlanguagereader.domain.client.elasticsearch.LookupAttempt
 import com.foreignlanguagereader.domain.util.ElasticsearchTestUtil
 import org.elasticsearch.action.index.IndexRequest
 import org.scalatest.funspec.AnyFunSpec
+import play.api.libs.json.{Json, Writes}
 
 class ElasticsearchSearchResultTest extends AnyFunSpec {
   val index: String = "definition"
@@ -76,7 +77,7 @@ class ElasticsearchSearchResultTest extends AnyFunSpec {
       source = DefinitionSource.MULTIPLE,
       token = "你好"
     )
-    val dummyGenericDefinition = GenericDefinition(
+    val dummyEnglishDefinition = EnglishDefinition(
       subdefinitions = List("definition 1", "definition 2"),
       ipa = "ipa",
       tag = PartOfSpeech.NOUN,
@@ -87,16 +88,19 @@ class ElasticsearchSearchResultTest extends AnyFunSpec {
       token = "anything"
     )
 
+    implicit val writes: Writes[EnglishDefinition] =
+      Json.writes[EnglishDefinition]
+
     val chineseDefinitionRequest =
       ElasticsearchTestUtil.indexRequestFrom(index, dummyChineseDefinition)
     val genericDefinitionRequest =
-      ElasticsearchTestUtil.indexRequestFrom(index, dummyGenericDefinition)
+      ElasticsearchTestUtil.indexRequestFrom(index, dummyEnglishDefinition)
 
     describe("on a previously untried query") {
       val result = ElasticsearchSearchResult[Definition](
         index = index,
         fields = fields,
-        result = List(dummyChineseDefinition, dummyGenericDefinition),
+        result = List(dummyChineseDefinition, dummyEnglishDefinition),
         fetchCount = 1,
         lookupId = None,
         refetched = true,
@@ -157,7 +161,7 @@ class ElasticsearchSearchResultTest extends AnyFunSpec {
       val result = ElasticsearchSearchResult[Definition](
         index = index,
         fields = fields,
-        result = List(dummyChineseDefinition, dummyGenericDefinition),
+        result = List(dummyChineseDefinition, dummyEnglishDefinition),
         fetchCount = 2,
         lookupId = Some(attemptsId),
         refetched = true,

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/client/elasticsearch/searchstates/ElasticsearchSearchResultTest.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/client/elasticsearch/searchstates/ElasticsearchSearchResultTest.scala
@@ -1,9 +1,8 @@
 package com.foreignlanguagereader.domain.client.elasticsearch.searchstates
 
 import com.foreignlanguagereader.content.types.Language
+import com.foreignlanguagereader.content.types.external.definition.wiktionary.WiktionaryDefinitionEntry
 import com.foreignlanguagereader.content.types.internal.definition.{
-  ChineseDefinition,
-  Definition,
   DefinitionSource,
   EnglishDefinition
 }
@@ -22,7 +21,7 @@ class ElasticsearchSearchResultTest extends AnyFunSpec {
   describe("an elasticsearch result") {
     describe("where nothing was refetched") {
       it("does not persist anything to elasticsearch") {
-        val result = ElasticsearchSearchResult[Definition](
+        val result = ElasticsearchSearchResult[WiktionaryDefinitionEntry](
           index = index,
           fields = fields,
           result = List(),
@@ -39,7 +38,7 @@ class ElasticsearchSearchResultTest extends AnyFunSpec {
     }
 
     describe("where refetching gave no result") {
-      val result = ElasticsearchSearchResult[Definition](
+      val result = ElasticsearchSearchResult[WiktionaryDefinitionEntry](
         index = index,
         fields = fields,
         result = List(),
@@ -66,26 +65,25 @@ class ElasticsearchSearchResultTest extends AnyFunSpec {
       }
     }
 
-    val dummyChineseDefinition = ChineseDefinition(
+    val dummyChineseDefinition = WiktionaryDefinitionEntry(
       subdefinitions = List("definition 1", "definition 2"),
-      tag = PartOfSpeech.NOUN,
+      pronunciation = "ni hao",
+      tag = Some(PartOfSpeech.NOUN),
       examples = Some(List("example 1", "example 2")),
-      inputPinyin = "ni3 hao3",
-      inputSimplified = Some("你好"),
-      inputTraditional = Some("你好"),
       definitionLanguage = Language.ENGLISH,
-      source = DefinitionSource.MULTIPLE,
-      token = "你好"
+      wordLanguage = Language.CHINESE,
+      token = "你好",
+      source = DefinitionSource.MULTIPLE
     )
-    val dummyEnglishDefinition = EnglishDefinition(
+    val dummyEnglishDefinition = WiktionaryDefinitionEntry(
       subdefinitions = List("definition 1", "definition 2"),
-      ipa = "ipa",
-      tag = PartOfSpeech.NOUN,
+      pronunciation = "ipa",
+      tag = Some(PartOfSpeech.NOUN),
       examples = Some(List("example 1", "example 2")),
       definitionLanguage = Language.ENGLISH,
       wordLanguage = Language.ENGLISH,
-      source = DefinitionSource.MULTIPLE,
-      token = "anything"
+      token = "anything",
+      source = DefinitionSource.MULTIPLE
     )
 
     implicit val writes: Writes[EnglishDefinition] =
@@ -97,7 +95,7 @@ class ElasticsearchSearchResultTest extends AnyFunSpec {
       ElasticsearchTestUtil.indexRequestFrom(index, dummyEnglishDefinition)
 
     describe("on a previously untried query") {
-      val result = ElasticsearchSearchResult[Definition](
+      val result = ElasticsearchSearchResult[WiktionaryDefinitionEntry](
         index = index,
         fields = fields,
         result = List(dummyChineseDefinition, dummyEnglishDefinition),
@@ -158,7 +156,7 @@ class ElasticsearchSearchResultTest extends AnyFunSpec {
       "on a query which previously failed but contained results this time"
     ) {
       val attemptsId = "2423423"
-      val result = ElasticsearchSearchResult[Definition](
+      val result = ElasticsearchSearchResult[WiktionaryDefinitionEntry](
         index = index,
         fields = fields,
         result = List(dummyChineseDefinition, dummyEnglishDefinition),

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/client/google/GoogleCloudClientTest.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/client/google/GoogleCloudClientTest.scala
@@ -40,7 +40,6 @@ class GoogleCloudClientTest extends AsyncFunSpec with MockitoSugar {
 
         client
           .getWordsForDocument(Language.ENGLISH, "test document")
-          .value
           .map {
             case CircuitBreakerAttempt(result) => assert(result.isEmpty)
             case _                             => fail("This isn't the happy path")

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/service/DocumentServiceTest.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/service/DocumentServiceTest.scala
@@ -1,10 +1,9 @@
 package com.foreignlanguagereader.domain.service
 
-import cats.data.Nested
 import com.foreignlanguagereader.content.types.Language
 import com.foreignlanguagereader.content.types.internal.definition.{
-  Definition,
-  DefinitionSource
+  DefinitionSource,
+  EnglishDefinition
 }
 import com.foreignlanguagereader.content.types.internal.word
 import com.foreignlanguagereader.content.types.internal.word.{
@@ -42,7 +41,7 @@ class DocumentServiceTest extends AsyncFunSpec with MockitoSugar {
       when(
         mockGoogleCloudClient
           .getWordsForDocument(Language.CHINESE, "some words")
-      ).thenReturn(Nested(Future.successful(CircuitBreakerAttempt(Set()))))
+      ).thenReturn(Future.successful(CircuitBreakerAttempt(Set())))
 
       documentService
         .getWordsForDocument(Language.CHINESE, Language.CHINESE, "some words")
@@ -53,7 +52,7 @@ class DocumentServiceTest extends AsyncFunSpec with MockitoSugar {
       when(
         mockGoogleCloudClient
           .getWordsForDocument(Language.CHINESE, "some words")
-      ).thenReturn(Nested(Future.successful(CircuitBreakerNonAttempt())))
+      ).thenReturn(Future.successful(CircuitBreakerNonAttempt()))
 
       documentService
         .getWordsForDocument(Language.CHINESE, Language.CHINESE, "some words")
@@ -65,10 +64,8 @@ class DocumentServiceTest extends AsyncFunSpec with MockitoSugar {
         mockGoogleCloudClient
           .getWordsForDocument(Language.CHINESE_TRADITIONAL, "some words")
       ).thenReturn(
-        Nested(
-          Future.apply(
-            CircuitBreakerFailedAttempt(new IllegalArgumentException("Uh oh"))
-          )
+        Future.apply(
+          CircuitBreakerFailedAttempt(new IllegalArgumentException("Uh oh"))
         )
       )
       documentService
@@ -114,10 +111,10 @@ class DocumentServiceTest extends AsyncFunSpec with MockitoSugar {
         mockGoogleCloudClient
           .getWordsForDocument(Language.ENGLISH, "test phrase")
       ).thenReturn(
-        Nested(Future.apply(CircuitBreakerAttempt(Set(testWord, phraseWord))))
+        Future.apply(CircuitBreakerAttempt(Set(testWord, phraseWord)))
       )
 
-      val testDefinition = Definition(
+      val testDefinition = EnglishDefinition(
         subdefinitions = List("test"),
         ipa = "",
         tag = PartOfSpeech.NOUN,
@@ -132,7 +129,7 @@ class DocumentServiceTest extends AsyncFunSpec with MockitoSugar {
           .getDefinition(Language.ENGLISH, Language.SPANISH, testWord)
       ).thenReturn(Future.successful(List(testDefinition)))
 
-      val phraseDefinition = Definition(
+      val phraseDefinition = EnglishDefinition(
         subdefinitions = List("phrase"),
         ipa = "",
         tag = PartOfSpeech.VERB,

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/service/definition/ChineseDefinitionServiceTest.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/service/definition/ChineseDefinitionServiceTest.scala
@@ -93,16 +93,16 @@ class ChineseDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
       // So the assertions may fail if that changes.
       when(
         elasticsearchClientMock
-          .findFromCacheOrRefetch[Definition](
-            any(classOf[List[ElasticsearchSearchRequest[Definition]]])
+          .findFromCacheOrRefetch[ChineseDefinition](
+            any(classOf[ElasticsearchSearchRequest[ChineseDefinition]])
           )(
-            any(classOf[ClassTag[Definition]]),
-            any(classOf[Reads[Definition]]),
-            any(classOf[Writes[Definition]])
+            any(classOf[ClassTag[ChineseDefinition]]),
+            any(classOf[Reads[ChineseDefinition]]),
+            any(classOf[Writes[ChineseDefinition]])
           )
       ).thenReturn(
         Future.successful(
-          List(List(dummyCedictDefinition), List(dummyWiktionaryDefinition))
+          List(dummyWiktionaryDefinition)
         )
       )
 
@@ -120,7 +120,7 @@ class ChineseDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
         when(
           elasticsearchClientMock
             .findFromCacheOrRefetch(
-              any(classOf[List[ElasticsearchSearchRequest[Definition]]])
+              any(classOf[ElasticsearchSearchRequest[Definition]])
             )(
               any(classOf[ClassTag[Definition]]),
               any(classOf[Reads[Definition]]),
@@ -144,7 +144,7 @@ class ChineseDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
         when(
           elasticsearchClientMock
             .findFromCacheOrRefetch(
-              any(classOf[List[ElasticsearchSearchRequest[Definition]]])
+              any(classOf[ElasticsearchSearchRequest[Definition]])
             )(
               any(classOf[ClassTag[Definition]]),
               any(classOf[Reads[Definition]]),
@@ -166,7 +166,7 @@ class ChineseDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
         when(
           elasticsearchClientMock
             .findFromCacheOrRefetch(
-              any(classOf[List[ElasticsearchSearchRequest[Definition]]])
+              any(classOf[ElasticsearchSearchRequest[Definition]])
             )(
               any(classOf[ClassTag[Definition]]),
               any(classOf[Reads[Definition]]),
@@ -215,7 +215,7 @@ class ChineseDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
         when(
           elasticsearchClientMock
             .findFromCacheOrRefetch(
-              any(classOf[List[ElasticsearchSearchRequest[Definition]]])
+              any(classOf[ElasticsearchSearchRequest[Definition]])
             )(
               any(classOf[ClassTag[Definition]]),
               any(classOf[Reads[Definition]]),

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/service/definition/ChineseDefinitionServiceTest.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/service/definition/ChineseDefinitionServiceTest.scala
@@ -119,15 +119,13 @@ class ChineseDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
     it("Does not enhance non-chinese definitions") {
       // This will delegate to the base LanguageDefinitionService implementation
       // So the assertions may fail if that changes.
-      stubFor[CEDICTDefinitionEntry](List(dummyCedictDefinitionEntry))
       stubFor[WiktionaryDefinitionEntry](List(dummyWiktionaryDefinitionEntry))
 
       chineseDefinitionService
         .getDefinitions(Language.CHINESE, niHao)
         .map { definitions =>
-          assert(definitions.size == 2)
-          assert(definitions.exists(_.eq(dummyCedictDefinition)))
-          assert(definitions.exists(_.eq(dummyWiktionaryDefinition)))
+          assert(definitions.size == 1)
+          assert(definitions.contains(dummyWiktionaryDefinition))
         }
     }
 

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/service/definition/DefinitionServiceTest.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/service/definition/DefinitionServiceTest.scala
@@ -102,7 +102,7 @@ class DefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
         .getDefinition(Language.SPANISH, Language.ENGLISH, cualquier)
         .map { response =>
           assert(response.size == 1)
-          assert(response.head == dummyEnglishDefinition)
+          assert(response.head == dummySpanishDefinition)
         }
     }
   }

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/service/definition/DefinitionServiceTest.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/service/definition/DefinitionServiceTest.scala
@@ -4,7 +4,8 @@ import com.foreignlanguagereader.content.types.Language
 import com.foreignlanguagereader.content.types.internal.definition.{
   ChineseDefinition,
   DefinitionSource,
-  GenericDefinition
+  EnglishDefinition,
+  SpanishDefinition
 }
 import com.foreignlanguagereader.content.types.internal.word.{
   PartOfSpeech,
@@ -42,7 +43,7 @@ class DefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
     source = DefinitionSource.MULTIPLE,
     token = "你好"
   )
-  val dummyGenericDefinition: GenericDefinition = GenericDefinition(
+  val dummyEnglishDefinition: EnglishDefinition = EnglishDefinition(
     subdefinitions = List("definition 1", "definition 2"),
     ipa = "",
     tag = PartOfSpeech.NOUN,
@@ -51,6 +52,17 @@ class DefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
     wordLanguage = Language.ENGLISH,
     source = DefinitionSource.MULTIPLE,
     token = "anything"
+  )
+
+  val dummySpanishDefinition: SpanishDefinition = SpanishDefinition(
+    subdefinitions = List("definition 1", "definition 2"),
+    ipa = "",
+    tag = PartOfSpeech.NOUN,
+    examples = Some(List("example 1", "example 2")),
+    definitionLanguage = Language.ENGLISH,
+    wordLanguage = Language.SPANISH,
+    source = DefinitionSource.MULTIPLE,
+    token = "cualquier"
   )
 
   val suoYouDe: Word = Word.fromToken("所有的", Language.CHINESE)
@@ -72,25 +84,25 @@ class DefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
 
     it("can get definitions in English") {
       when(mockEnglishService.getDefinitions(Language.CHINESE, anything))
-        .thenReturn(Future.successful(List(dummyGenericDefinition)))
+        .thenReturn(Future.successful(List(dummyEnglishDefinition)))
 
       definitionService
         .getDefinition(Language.ENGLISH, Language.CHINESE, anything)
         .map { response =>
           assert(response.size == 1)
-          assert(response.head == dummyGenericDefinition)
+          assert(response.head == dummyEnglishDefinition)
         }
     }
 
     it("can get definitions in Spanish") {
       when(mockSpanishService.getDefinitions(Language.ENGLISH, cualquier))
-        .thenReturn(Future.successful(List(dummyGenericDefinition)))
+        .thenReturn(Future.successful(List(dummySpanishDefinition)))
 
       definitionService
         .getDefinition(Language.SPANISH, Language.ENGLISH, cualquier)
         .map { response =>
           assert(response.size == 1)
-          assert(response.head == dummyGenericDefinition)
+          assert(response.head == dummyEnglishDefinition)
         }
     }
   }

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/service/definition/LanguageDefinitionServiceTest.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/service/definition/LanguageDefinitionServiceTest.scala
@@ -231,9 +231,13 @@ class LanguageDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
         ] = Map(
           (
             DefinitionSource.WIKTIONARY,
-            Language.SPANISH
+            Language.ENGLISH
           ) -> new WiktionarySpanishFetcher()(ec)
         )
+        override val sources: List[DefinitionSource] =
+          List(
+            DefinitionSource.WIKTIONARY
+          )
 
         override def enrichDefinitions(
             definitionLanguage: Language,
@@ -285,7 +289,10 @@ class LanguageDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
             assert(results.length == 1)
             assert(
               results.contains(
-                dummyWiktionaryDefinition.toDefinition(PartOfSpeech.NOUN)
+                DefinitionEntry.buildSpanishDefinition(
+                  dummyWiktionaryDefinition,
+                  PartOfSpeech.NOUN
+                )
               )
             )
 

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/service/definition/LanguageDefinitionServiceTest.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/service/definition/LanguageDefinitionServiceTest.scala
@@ -2,6 +2,7 @@ package com.foreignlanguagereader.domain.service.definition
 
 import com.foreignlanguagereader.content.types.Language
 import com.foreignlanguagereader.content.types.Language.Language
+import com.foreignlanguagereader.content.types.external.definition.DefinitionEntry
 import com.foreignlanguagereader.content.types.external.definition.cedict.CEDICTDefinitionEntry
 import com.foreignlanguagereader.content.types.external.definition.webster.WebsterSpanishDefinitionEntry
 import com.foreignlanguagereader.content.types.external.definition.wiktionary.WiktionaryDefinitionEntry
@@ -198,13 +199,13 @@ class LanguageDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
         when(
           elasticsearchClientMock
             .findFromCacheOrRefetch(
-              any(classOf[List[ElasticsearchSearchRequest[Definition]]])
+              any(classOf[ElasticsearchSearchRequest[Definition]])
             )(
               any(classOf[ClassTag[Definition]]),
               any(classOf[Reads[Definition]]),
               any(classOf[Writes[Definition]])
             )
-        ).thenReturn(Future.successful(List(List())))
+        ).thenReturn(Future.successful(List()))
 
         customizedFetcher
           .getDefinitions(Language.CHINESE, test)
@@ -244,18 +245,15 @@ class LanguageDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
         when(
           elasticsearchClientMock
             .findFromCacheOrRefetch(
-              any(classOf[List[ElasticsearchSearchRequest[Definition]]])
+              any(classOf[ElasticsearchSearchRequest[DefinitionEntry]])
             )(
-              any(classOf[ClassTag[Definition]]),
-              any(classOf[Reads[Definition]]),
-              any(classOf[Writes[Definition]])
+              any(classOf[ClassTag[DefinitionEntry]]),
+              any(classOf[Reads[DefinitionEntry]]),
+              any(classOf[Writes[DefinitionEntry]])
             )
         ).thenReturn(
           Future.successful(
-            List(
-              List(dummyCEDICTDefinition.toDefinition(PartOfSpeech.NOUN)),
-              List(dummyWiktionaryDefinition.toDefinition(PartOfSpeech.NOUN))
-            )
+            List(dummyCEDICTDefinition, dummyWiktionaryDefinition)
           )
         )
 

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/service/definition/LanguageDefinitionServiceTest.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/service/definition/LanguageDefinitionServiceTest.scala
@@ -1,14 +1,16 @@
 package com.foreignlanguagereader.domain.service.definition
 
-import cats.data.Nested
 import com.foreignlanguagereader.content.types.Language
 import com.foreignlanguagereader.content.types.Language.Language
 import com.foreignlanguagereader.content.types.external.definition.cedict.CEDICTDefinitionEntry
+import com.foreignlanguagereader.content.types.external.definition.webster.WebsterSpanishDefinitionEntry
 import com.foreignlanguagereader.content.types.external.definition.wiktionary.WiktionaryDefinitionEntry
 import com.foreignlanguagereader.content.types.internal.definition.DefinitionSource.DefinitionSource
 import com.foreignlanguagereader.content.types.internal.definition.{
   Definition,
-  DefinitionSource
+  DefinitionSource,
+  EnglishDefinition,
+  SpanishDefinition
 }
 import com.foreignlanguagereader.content.types.internal.word.{
   PartOfSpeech,
@@ -18,6 +20,8 @@ import com.foreignlanguagereader.domain.client.MirriamWebsterClient
 import com.foreignlanguagereader.domain.client.common.CircuitBreakerResult
 import com.foreignlanguagereader.domain.client.elasticsearch.ElasticsearchCacheClient
 import com.foreignlanguagereader.domain.client.elasticsearch.searchstates.ElasticsearchSearchRequest
+import com.foreignlanguagereader.domain.fetcher.DefinitionFetcher
+import com.foreignlanguagereader.domain.fetcher.spanish.WebsterSpanishToEnglishFetcher
 import org.mockito.ArgumentMatchers.any
 import org.mockito.MockitoSugar
 import org.scalatest.FutureOutcome
@@ -55,7 +59,8 @@ class LanguageDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
   }
 
   describe("A default language definition service") {
-    class DefaultLanguageDefinitionService() extends LanguageDefinitionService {
+    class DefaultLanguageDefinitionService()
+        extends LanguageDefinitionService[EnglishDefinition] {
       val elasticsearch: ElasticsearchCacheClient = elasticsearchClientMock
       implicit val ec: ExecutionContext =
         scala.concurrent.ExecutionContext.Implicits.global
@@ -70,18 +75,16 @@ class LanguageDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
       when(
         elasticsearchClientMock
           .findFromCacheOrRefetch(
-            any(classOf[List[ElasticsearchSearchRequest[Definition]]])
+            any(classOf[ElasticsearchSearchRequest[WiktionaryDefinitionEntry]])
           )(
-            any(classOf[ClassTag[Definition]]),
-            any(classOf[Reads[Definition]]),
-            any(classOf[Writes[Definition]])
+            any(classOf[ClassTag[WiktionaryDefinitionEntry]]),
+            any(classOf[Reads[WiktionaryDefinitionEntry]]),
+            any(classOf[Writes[WiktionaryDefinitionEntry]])
           )
       ).thenReturn(
         Future
           .successful(
-            List(
-              List(dummyWiktionaryDefinition.toDefinition(PartOfSpeech.NOUN))
-            )
+            List(dummyWiktionaryDefinition)
           )
       )
       defaultDefinitionService
@@ -99,13 +102,13 @@ class LanguageDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
       when(
         elasticsearchClientMock
           .findFromCacheOrRefetch(
-            any(classOf[List[ElasticsearchSearchRequest[Definition]]])
+            any(classOf[ElasticsearchSearchRequest[WiktionaryDefinitionEntry]])
           )(
-            any(classOf[ClassTag[Definition]]),
-            any(classOf[Reads[Definition]]),
-            any(classOf[Writes[Definition]])
+            any(classOf[ClassTag[WiktionaryDefinitionEntry]]),
+            any(classOf[Reads[WiktionaryDefinitionEntry]]),
+            any(classOf[Writes[WiktionaryDefinitionEntry]])
           )
-      ).thenReturn(Future.successful(List(List())))
+      ).thenReturn(Future.successful(List()))
 
       defaultDefinitionService
         .getDefinitions(Language.ENGLISH, test)
@@ -125,7 +128,7 @@ class LanguageDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
     )
 
     class CustomizedLanguageDefinitionService()
-        extends LanguageDefinitionService {
+        extends LanguageDefinitionService[SpanishDefinition] {
       val elasticsearch: ElasticsearchCacheClient = elasticsearchClientMock
       implicit val ec: ExecutionContext =
         scala.concurrent.ExecutionContext.Implicits.global
@@ -133,8 +136,7 @@ class LanguageDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
       override val wordLanguage: Language = Language.SPANISH
       override val sources: List[DefinitionSource] =
         List(
-          DefinitionSource.MIRRIAM_WEBSTER_SPANISH,
-          DefinitionSource.WIKTIONARY
+          DefinitionSource.MIRRIAM_WEBSTER_SPANISH
         )
     }
 
@@ -145,23 +147,14 @@ class LanguageDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
       class CustomizedFetcherLanguageDefinitionService
           extends CustomizedLanguageDefinitionService {
 
-        val websterFetcher: (
-            Language,
-            Word
-        ) => Nested[Future, CircuitBreakerResult, List[Definition]] =
-          (_: Language, word: Word) => websterMock.getSpanishDefinition(word)
-
         override val definitionFetchers: Map[
           (DefinitionSource, Language),
-          (
-              Language,
-              Word
-          ) => Nested[Future, CircuitBreakerResult, List[Definition]]
+          DefinitionFetcher[_, SpanishDefinition]
         ] = Map(
           (
             DefinitionSource.MIRRIAM_WEBSTER_SPANISH,
             Language.SPANISH
-          ) -> websterFetcher
+          ) -> new WebsterSpanishToEnglishFetcher(websterMock)(ec)
         )
       }
       val customizedFetcher = new CustomizedFetcherLanguageDefinitionService()
@@ -170,23 +163,26 @@ class LanguageDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
         when(
           elasticsearchClientMock
             .findFromCacheOrRefetch(
-              any(classOf[List[ElasticsearchSearchRequest[Definition]]])
+              any(
+                classOf[
+                  ElasticsearchSearchRequest[WebsterSpanishDefinitionEntry]
+                ]
+              )
             )(
-              any(classOf[ClassTag[Definition]]),
-              any(classOf[Reads[Definition]]),
-              any(classOf[Writes[Definition]])
+              any(classOf[ClassTag[WebsterSpanishDefinitionEntry]]),
+              any(classOf[Reads[WebsterSpanishDefinitionEntry]]),
+              any(classOf[Writes[WebsterSpanishDefinitionEntry]])
             )
-        ).thenReturn(Future.successful(List(List())))
+        ).thenReturn(Future.successful(List()))
         when(
           websterMock.getSpanishDefinition(
             Word.fromToken("test", Language.SPANISH)
           )
         ).thenReturn(
-          Nested(
-            Future.failed[CircuitBreakerResult[List[Definition]]](
+          Future
+            .failed[CircuitBreakerResult[List[WebsterSpanishDefinitionEntry]]](
               new IllegalStateException("Uh oh")
             )
-          )
         )
 
         customizedFetcher

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/service/definition/LanguageDefinitionServiceTest.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/service/definition/LanguageDefinitionServiceTest.scala
@@ -81,7 +81,7 @@ class LanguageDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
         (
           DefinitionSource.WIKTIONARY,
           Language.ENGLISH
-        ) -> new WiktionaryEnglishFetcher()(ec)
+        ) -> new WiktionaryEnglishFetcher()
       )
     }
     val defaultDefinitionService = new DefaultLanguageDefinitionService()
@@ -162,7 +162,7 @@ class LanguageDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
           (
             DefinitionSource.MIRRIAM_WEBSTER_SPANISH,
             Language.SPANISH
-          ) -> new WebsterSpanishToEnglishFetcher(websterMock)(ec)
+          ) -> new WebsterSpanishToEnglishFetcher(websterMock)
         )
       }
       val customizedFetcher = new CustomizedFetcherLanguageDefinitionService()
@@ -232,7 +232,7 @@ class LanguageDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
           (
             DefinitionSource.WIKTIONARY,
             Language.ENGLISH
-          ) -> new WiktionarySpanishFetcher()(ec)
+          ) -> new WiktionarySpanishFetcher()
         )
         override val sources: List[DefinitionSource] =
           List(


### PR DESCRIPTION
## Enhancement
We store our processed definitions for each source in elasticsearch. However, if we ever add new fields, then we'll have to reprocess all the definitions. Instead, let's store the definitions raw and pull the relevant fields out at load time. 

### Won't that be slow?
We can add a cache later on if performance becomes an issue.

### New pattern: Fetchers
Fetchers hold all the logic for getting definitions from a specific source. That way definition services don't need to know the how of getting definitions, just which ones to call.