### PR TITLE
Wrap Elasticsearch caching in a container object

### DIFF
--- a/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchCacheClient.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchCacheClient.scala
@@ -38,8 +38,13 @@ class ElasticsearchCacheClient @Inject() (
       reads: Reads[T],
       writes: Writes[T]
   ): Future[List[T]] = {
+    implicit val readsCacheable: Reads[ElasticsearchCacheable[T]] =
+      ElasticsearchCacheable.reads[T]
+    implicit val writesCacheable: Writes[ElasticsearchCacheable[T]] =
+      ElasticsearchCacheable.writes[T]
+
     client
-      .doubleSearch[T, LookupAttempt](request.query)
+      .doubleSearch[ElasticsearchCacheable[T], LookupAttempt](request.query)
       .map(result => ElasticsearchSearchResponse.fromResult(request, result))
       // This is where fetchers are called to get results if they aren't in elasticsearch
       // There is also logic to remember what has been fetched from external sources

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchCacheable.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchCacheable.scala
@@ -1,0 +1,23 @@
+package com.foreignlanguagereader.domain.client.elasticsearch
+
+import play.api.libs.functional.syntax.{toFunctionalBuilderOps, unlift}
+import play.api.libs.json.{JsPath, Reads, Writes}
+
+case class ElasticsearchCacheable[T](item: T, fields: Map[String, String])
+object ElasticsearchCacheable {
+  implicit def reads[T](implicit
+      r: Reads[T]
+  ): Reads[ElasticsearchCacheable[T]] =
+    (
+      (JsPath \ "item").read(r) and
+        (JsPath \ "fields").read[Map[String, String]]
+    )(ElasticsearchCacheable.apply[T] _)
+
+  implicit def writes[T](implicit
+      w: Writes[T]
+  ): Writes[ElasticsearchCacheable[T]] =
+    (
+      (JsPath \ "item").write(w) and
+        (JsPath \ "fields").write[Map[String, String]]
+    )(unlift(ElasticsearchCacheable.unapply[T]))
+}

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/searchstates/ElasticsearchSearchRequest.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/searchstates/ElasticsearchSearchRequest.scala
@@ -42,7 +42,7 @@ case class ElasticsearchSearchRequest[T](
   val searchQuery: SearchRequest = {
     val q = fields.foldLeft(QueryBuilders.boolQuery()) {
       case (acc, (field, value)) =>
-        acc.must(QueryBuilders.matchQuery(field, value))
+        acc.must(QueryBuilders.matchQuery(s"fields.field", value))
     }
     new SearchRequest()
       .source(new SearchSourceBuilder().query(q))

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/searchstates/ElasticsearchSearchResult.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/searchstates/ElasticsearchSearchResult.scala
@@ -1,7 +1,10 @@
 package com.foreignlanguagereader.domain.client.elasticsearch.searchstates
 
 import cats.implicits._
-import com.foreignlanguagereader.domain.client.elasticsearch.LookupAttempt
+import com.foreignlanguagereader.domain.client.elasticsearch.{
+  ElasticsearchCacheable,
+  LookupAttempt
+}
 import org.elasticsearch.action.index.IndexRequest
 import org.elasticsearch.action.update.UpdateRequest
 import org.elasticsearch.common.xcontent.XContentType
@@ -37,8 +40,10 @@ case class ElasticsearchSearchResult[T: Writes](
       case values if refetched && values.nonEmpty =>
         values
           .map(v => {
+            val cacheable: ElasticsearchCacheable[T] =
+              ElasticsearchCacheable(v, fields)
             new IndexRequest()
-              .source(Json.toJson(v).toString(), XContentType.JSON)
+              .source(Json.toJson(cacheable).toString(), XContentType.JSON)
               .index(index)
               .asLeft
           })

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/client/elasticsearch/searchstates/ElasticsearchSearchResultTest.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/client/elasticsearch/searchstates/ElasticsearchSearchResultTest.scala
@@ -90,9 +90,17 @@ class ElasticsearchSearchResultTest extends AnyFunSpec {
       Json.writes[EnglishDefinition]
 
     val chineseDefinitionRequest =
-      ElasticsearchTestUtil.indexRequestFrom(index, dummyChineseDefinition)
+      ElasticsearchTestUtil.indexRequestFrom(
+        index,
+        dummyChineseDefinition,
+        fields
+      )
     val genericDefinitionRequest =
-      ElasticsearchTestUtil.indexRequestFrom(index, dummyEnglishDefinition)
+      ElasticsearchTestUtil.indexRequestFrom(
+        index,
+        dummyEnglishDefinition,
+        fields
+      )
 
     describe("on a previously untried query") {
       val result = ElasticsearchSearchResult[WiktionaryDefinitionEntry](

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/util/ElasticsearchTestUtil.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/util/ElasticsearchTestUtil.scala
@@ -1,6 +1,9 @@
 package com.foreignlanguagereader.domain.util
 
-import com.foreignlanguagereader.domain.client.elasticsearch.LookupAttempt
+import com.foreignlanguagereader.domain.client.elasticsearch.{
+  ElasticsearchCacheable,
+  LookupAttempt
+}
 import org.elasticsearch.action.index.IndexRequest
 import org.elasticsearch.action.update.UpdateRequest
 import org.elasticsearch.common.xcontent.XContentType
@@ -21,7 +24,21 @@ object ElasticsearchTestUtil {
       .upsert(Json.toJson(attempt).toString(), XContentType.JSON)
   }
 
-  def indexRequestFrom[T](index: String, item: T)(implicit
+  def indexRequestFrom[T](
+      index: String,
+      item: T,
+      fields: Map[String, String]
+  )(implicit
+      writes: Writes[T]
+  ): IndexRequest = {
+    val cacheable = ElasticsearchCacheable(item, fields)
+    indexRequestFrom(index, cacheable)
+  }
+
+  private[this] def indexRequestFrom[T](
+      index: String,
+      item: T
+  )(implicit
       writes: Writes[T]
   ): IndexRequest = {
     new IndexRequest()


### PR DESCRIPTION
## Problem
There have been multiple bugs where an object to be cached doesn't write out the field needed to find itself again. This burden is passed on to the programmer. 

## Solution
Wrap the items in a class which contains the search field. This guarantees it is always saved in elasticsearch, and thus findable.