### PR TITLE
Cleaning graphql out

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,10 +2,9 @@
 .github/*
 .idea/*
 .terraform/*
-frontend/*
-language-service/*
 logs/*
 target/*
+.bsp/*
 
 *.tf
 *.tfvars
@@ -15,3 +14,10 @@ target/*
 codecov.yml
 local_setup.yml
 state.json
+
+api/target/*
+client/target/*
+content/target/*
+domain/target/*
+dto/target/*
+jobs/target/*

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,10 +89,10 @@ jobs:
 
       - name: Update image in K8s
         run: |
-          kubectl --kubeconfig=$GITHUB_WORKSPACE/.kubeconfig -n prod \
+          kubectl --kubeconfig=$GITHUB_WORKSPACE/.kubeconfig \
             set image deployment/api api=lkjaero/foreign-language-reader-api:${{ env.RELEASE_VERSION}} --record
 
       - name: Wait for deployment to finish
         run: |
-          kubectl --kubeconfig=$GITHUB_WORKSPACE/.kubeconfig -n prod \
+          kubectl --kubeconfig=$GITHUB_WORKSPACE/.kubeconfig \
             rollout status deployment/api

--- a/api/app/com/foreignlanguagereader/api/configuration/Log4J2LoggerConfigurator.scala
+++ b/api/app/com/foreignlanguagereader/api/configuration/Log4J2LoggerConfigurator.scala
@@ -1,11 +1,13 @@
-import java.io.File
-import java.net.URL
+package com.foreignlanguagereader.api.configuration
 
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.core.LoggerContext
 import org.apache.logging.log4j.core.config.Configurator
 import org.slf4j.ILoggerFactory
 import play.api.{Configuration, Environment, LoggerConfigurator, Mode}
+
+import java.io.File
+import java.net.URL
 
 class Log4J2LoggerConfigurator extends LoggerConfigurator {
 

--- a/api/conf/application.conf
+++ b/api/conf/application.conf
@@ -33,7 +33,6 @@ elasticsearch {
   timeout = 5
   username = "local"
   password = "local"
-  truststore = "password"
 }
 
 webster-context {

--- a/api/conf/logger-configurator.properties
+++ b/api/conf/logger-configurator.properties
@@ -1,1 +1,1 @@
-play.logger.configurator=Log4J2LoggerConfigurator
+play.logger.configurator=com.foreignlanguagereader.api.configuration.Log4J2LoggerConfigurator

--- a/api/conf/production.conf
+++ b/api/conf/production.conf
@@ -36,7 +36,6 @@ elasticsearch {
   timeout = 5
   username = "apiprod"
   password = ${?ELASTICSEARCH_PASSWORD}
-  truststore = ${?TRUSTSTORE_PASSWORD}
 }
 
 webster-context {

--- a/api/conf/production.conf
+++ b/api/conf/production.conf
@@ -31,7 +31,7 @@ elasticsearch-context {
 }
 elasticsearch {
   scheme = "https"
-  url = "content-es-http.content.svc.cluster.local"
+  url = "elastic.foreignlanguagereader.com"
   port = 9200
   timeout = 5
   username = "apiprod"

--- a/build.sbt
+++ b/build.sbt
@@ -128,10 +128,6 @@ lazy val dependencies =
     // NLP tools
     val opencc4j = "com.github.houbb" % "opencc4j" % "1.6.0"
 
-    // Graphql
-    val sangria = "org.sangria-graphql" %% "sangria" % "2.0.0"
-    val sangriaPlay = "org.sangria-graphql" %% "sangria-play-json" % "2.0.0"
-
     // External clients
     val elasticsearchHighLevelClient =
       "org.elasticsearch.client" % "elasticsearch-rest-high-level-client" % elasticsearchVersion
@@ -158,8 +154,7 @@ lazy val commonDependencies = Seq(
   dependencies.scalatest % "test",
   dependencies.scalactic,
   dependencies.cats,
-  ws,
-  dependencies.sangria
+  ws
 )
 
 lazy val log4jDependencies = Seq(
@@ -171,8 +166,6 @@ lazy val log4jDependencies = Seq(
 
 lazy val playDependencies = Seq(
   dependencies.scalatestPlay,
-  dependencies.sangria,
-  dependencies.sangriaPlay,
   dependencies.mockito
 )
 

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/Language.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/Language.scala
@@ -3,8 +3,6 @@ package com.foreignlanguagereader.content.types
 import cats.implicits._
 import play.api.libs.json.{Reads, Writes}
 import play.api.mvc.PathBindable
-import sangria.macros.derive.{EnumTypeDescription, EnumTypeName, deriveEnumType}
-import sangria.schema.EnumType
 
 object Language extends Enumeration {
   type Language = Value
@@ -29,9 +27,4 @@ object Language extends Enumeration {
         }
       override def unbind(key: String, value: Language): String = value.toString
     }
-
-  val graphqlType: EnumType[Language] = deriveEnumType[Language](
-    EnumTypeName("Language"),
-    EnumTypeDescription("A human language")
-  )
 }

--- a/dto/src/main/scala/com/foreignlanguagereader/dto/v1/definition/chinese/ChinesePronunciation.scala
+++ b/dto/src/main/scala/com/foreignlanguagereader/dto/v1/definition/chinese/ChinesePronunciation.scala
@@ -1,8 +1,6 @@
 package com.foreignlanguagereader.dto.v1.definition.chinese
 
 import play.api.libs.json.{Format, Json}
-import sangria.macros.derive.{ObjectTypeDescription, deriveObjectType}
-import sangria.schema
 
 case class ChinesePronunciation(
     pinyin: String = "",
@@ -22,10 +20,4 @@ case class ChinesePronunciation(
 }
 object ChinesePronunciation {
   implicit val format: Format[ChinesePronunciation] = Json.format
-  implicit val graphQlType: schema.ObjectType[Unit, ChinesePronunciation] =
-    deriveObjectType[Unit, ChinesePronunciation](
-      ObjectTypeDescription(
-        "A holder of different pronunciation formats for Chinese words"
-      )
-    )
 }

--- a/jobs/src/main/scala/com/foreignlanguagereader/jobs/SparkSessionBuilder.scala
+++ b/jobs/src/main/scala/com/foreignlanguagereader/jobs/SparkSessionBuilder.scala
@@ -7,15 +7,9 @@ object SparkSessionBuilder {
   def build(name: String): SparkSession = {
     SparkSession.builder
       .appName(name)
-      .config("es.nodes", "content-es-http.content.svc.cluster.local")
+      .config("es.nodes", "elastic.foreignlanguagereader.com")
       .config("es.index.auto.create", "true")
       .config("es.net.ssl", "true")
-      .config("es.net.ssl.cert.allow.self.signed", "true")
-      .config(
-        "es.net.ssl.truststore.location",
-        "file:///etc/flrcredentials/spark_keystore.jks"
-      )
-      .config("es.net.ssl.truststore.pass", sys.env("es_truststore"))
       .config("es.net.http.auth.user", sys.env("es_user"))
       .config("es.net.http.auth.pass", sys.env("es_password"))
       .getOrCreate()


### PR DESCRIPTION
- Remove graphql
- Clean up docker build environment for faster builds
- Use new elasticsearch url
- Remove truststore because we are no longer using a self signed certificate for elasticsearch.