### PR TITLE
Don't rebuild dependencies image if nothing has changed

### DIFF
--- a/.github/workflows/scala_test.yml
+++ b/.github/workflows/scala_test.yml
@@ -39,9 +39,3 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         flags: unittest
-
-    - name: Run codacy-coverage-reporter
-      uses: codacy/codacy-coverage-reporter-action@master
-      with:
-        project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-        coverage-reports: api/target/scala-2.12/coverage-report/cobertura.xml, content/target/scala-2.12/coverage-report/cobertura.xml, domain/target/scala-2.12/coverage-report/cobertura.xml, jobs/target/scala-2.12/coverage-report/cobertura.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM lkjaero/foreign-language-reader-api:builder as builder
 
 # Compile the service
 COPY . /app/
-RUN sbt clean coverageOff dist
+RUN rm build-dependencies.sbt && \
+    sbt clean coverageOff dist
 
 # Detect the version and unzip to /app/dist
 # hadolint ignore=SC2086

--- a/Dockerfile_builder
+++ b/Dockerfile_builder
@@ -1,7 +1,7 @@
 # Use this to cache project dependencies for easy building
 FROM lkjaero/foreign-language-reader-api:base
 
-ENV SBT_VERSION 1.4.0
+ENV SBT_VERSION 1.3.9
 ENV INSTALL_DIR /usr/local
 ENV SBT_HOME /usr/local/sbt
 ENV PATH ${PATH}:${SBT_HOME}/bin
@@ -20,5 +20,6 @@ RUN apk add --no-cache wget=1.20.3-r1 && \
 
 # Cache dependencies
 COPY project project
-COPY build.sbt build.sbt
+COPY build-dependencies.sbt build.sbt
 RUN sbt compile
+RUN rm build.sbt

--- a/build-dependencies.sbt
+++ b/build-dependencies.sbt
@@ -1,0 +1,11 @@
+import Dependencies._
+
+name := "foreign-language-reader-parent"
+scalaVersion in ThisBuild := "2.12.12"
+
+lazy val dependencies = project
+  .in(file("."))
+  .settings(
+    libraryDependencies ++= ProjectDependencies.allDependencies,
+    dependencyOverrides ++= ProjectDependencies.forcedDependencies
+  )

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import sbtassembly.AssemblyPlugin.autoImport.assemblyMergeStrategy
+import Dependencies._
 
 name := "foreign-language-reader-parent"
 scalaVersion in ThisBuild := "2.12.12"
@@ -26,7 +27,7 @@ lazy val global = project
   .settings(
     settings,
     assemblySettings,
-    dependencyOverrides ++= forcedDependencies
+    dependencyOverrides ++= ProjectDependencies.forcedDependencies
   )
   .aggregate(api, content, domain, dto, jobs)
 
@@ -36,8 +37,8 @@ lazy val api = project
   .settings(
     settings,
     assemblySettings,
-    libraryDependencies ++= apiDependencies,
-    dependencyOverrides ++= forcedDependencies,
+    libraryDependencies ++= ProjectDependencies.apiDependencies,
+    dependencyOverrides ++= ProjectDependencies.forcedDependencies,
     javaOptions += "-Dlog4j.configurationFile=log4j2.xml"
   )
   .dependsOn(domain)
@@ -46,8 +47,8 @@ lazy val content = project
   .settings(
     settings,
     assemblySettings,
-    libraryDependencies ++= contentDependencies,
-    dependencyOverrides ++= forcedDependencies
+    libraryDependencies ++= ProjectDependencies.contentDependencies,
+    dependencyOverrides ++= ProjectDependencies.forcedDependencies
   )
   .dependsOn(dto)
 
@@ -55,8 +56,8 @@ lazy val domain = project
   .settings(
     settings,
     assemblySettings,
-    libraryDependencies ++= domainDependencies,
-    dependencyOverrides ++= forcedDependencies
+    libraryDependencies ++= ProjectDependencies.domainDependencies,
+    dependencyOverrides ++= ProjectDependencies.forcedDependencies
   )
   .dependsOn(content)
 
@@ -64,8 +65,8 @@ lazy val dto = project
   .settings(
     settings,
     assemblySettings,
-    libraryDependencies ++= dtoDependencies,
-    dependencyOverrides ++= forcedDependencies
+    libraryDependencies ++= ProjectDependencies.dtoDependencies,
+    dependencyOverrides ++= ProjectDependencies.forcedDependencies
   )
 
 lazy val jobs = project
@@ -73,166 +74,10 @@ lazy val jobs = project
   .settings(
     settings,
     assemblySettings,
-    libraryDependencies ++= jobsDependencies,
-    dependencyOverrides ++= forcedDependencies
+    libraryDependencies ++= ProjectDependencies.jobsDependencies,
+    dependencyOverrides ++= ProjectDependencies.forcedDependencies
   )
   .dependsOn(content)
-
-/*
- * Dependencies
- */
-
-lazy val dependencies =
-  new {
-    val scalatestVersion = "3.2.2"
-    val jacksonVersion = "2.11.3"
-    val log4jVersion = "2.14.0"
-    val elasticsearchVersion = "7.10.1"
-    val sparkVersion = "3.0.1"
-    val hadoopVersion = "2.7.4"
-    val prometheusVersion = "0.9.0"
-
-    // Testing
-    val scalactic = "org.scalactic" %% "scalactic" % scalatestVersion
-    val scalatest = "org.scalatest" %% "scalatest" % scalatestVersion
-    val scalatestPlay =
-      "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test
-    val mockito = "org.mockito" %% "mockito-scala" % "1.16.0" % Test
-    val elasticsearchContainer =
-      "org.testcontainers" % "elasticsearch" % "1.15.0"
-
-    // Language helpers
-    val cats = "org.typelevel" %% "cats-core" % "2.0.0"
-    val lombok = "org.projectlombok" % "lombok" % "1.18.16"
-
-    val log4jImplementation =
-      "org.apache.logging.log4j" % "log4j-slf4j-impl" % log4jVersion
-    val log4jApi = "org.apache.logging.log4j" % "log4j-api" % log4jVersion
-    val log4jCore = "org.apache.logging.log4j" % "log4j-core" % log4jVersion
-    val log4jJson =
-      "org.apache.logging.log4j" % "log4j-layout-template-json" % log4jVersion
-
-    val prometheusClient = "io.prometheus" % "simpleclient" % prometheusVersion
-    val prometheusCommon =
-      "io.prometheus" % "simpleclient_common" % prometheusVersion
-    val prometheusHotspot =
-      "io.prometheus" % "simpleclient_hotspot" % prometheusVersion
-
-    // Spark
-    val sparkCore =
-      "org.apache.spark" %% "spark-core" % sparkVersion
-    val sparkSql = "org.apache.spark" %% "spark-sql" % sparkVersion
-    val sparkXml = "com.databricks" %% "spark-xml" % "0.10.0"
-    val hadoop = "org.apache.hadoop" % "hadoop-common" % hadoopVersion
-    val hadoopClient = "org.apache.hadoop" % "hadoop-client" % hadoopVersion
-    val hadoopAWS = "org.apache.hadoop" % "hadoop-aws" % hadoopVersion
-    val awsJavaSDK = "com.amazonaws" % "aws-java-sdk" % "1.7.4"
-    // Enable this when it is build for scala 2.12 in main
-    // And remove our local version
-//    val elasticsearchHadoop =
-//      "org.elasticsearch" % "elasticsearch-hadoop" % elasticsearchVersion
-
-    // NLP tools
-    val opencc4j = "com.github.houbb" % "opencc4j" % "1.6.0"
-
-    // External clients
-    val elasticsearchHighLevelClient =
-      "org.elasticsearch.client" % "elasticsearch-rest-high-level-client" % elasticsearchVersion
-    val oslib = "com.lihaoyi" %% "os-lib" % "0.7.1"
-    val googleCloudClient =
-      "com.google.cloud" % "google-cloud-language" % "1.101.6"
-
-    // Hacks for guava incompatibility
-    val hadoopMapreduceClient =
-      "org.apache.hadoop" % "hadoop-mapreduce-client-core" % "2.7.2"
-
-    // Security related dependency upgrades below here
-    val jacksonScala =
-      "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion
-    val jacksonDatabind =
-      "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
-    val jacksonCore =
-      "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion
-    val htrace = "org.apache.htrace" % "htrace-core" % "4.0.0-incubating"
-    val avro = "org.apache.avro" % "avro" % "1.10.0"
-  }
-
-lazy val commonDependencies = Seq(
-  dependencies.scalatest % "test",
-  dependencies.scalactic,
-  dependencies.cats,
-  ws
-)
-
-lazy val log4jDependencies = Seq(
-  dependencies.log4jApi,
-  dependencies.log4jCore,
-  dependencies.log4jImplementation,
-  dependencies.log4jJson
-)
-
-lazy val playDependencies = Seq(
-  dependencies.scalatestPlay,
-  dependencies.mockito
-)
-
-lazy val forcedDependencies = Seq(
-  dependencies.hadoopMapreduceClient,
-  dependencies.jacksonScala,
-  dependencies.jacksonDatabind,
-  dependencies.jacksonCore,
-  dependencies.lombok,
-  dependencies.htrace,
-  dependencies.hadoop,
-  dependencies.avro,
-  dependencies.log4jApi,
-  dependencies.log4jCore,
-  dependencies.log4jImplementation,
-  dependencies.log4jJson
-)
-
-lazy val apiDependencies =
-  commonDependencies ++ playDependencies ++ log4jDependencies ++ Seq(
-    dependencies.prometheusClient,
-    dependencies.prometheusHotspot,
-    dependencies.prometheusCommon
-  )
-
-lazy val contentDependencies = commonDependencies ++ Seq(
-  dependencies.scalatestPlay,
-  dependencies.opencc4j
-)
-
-lazy val domainDependencies = commonDependencies ++ Seq(
-  // Dependency injection
-  guice,
-  // Used to generate elasticsearch matchers
-  dependencies.elasticsearchHighLevelClient,
-  dependencies.oslib,
-  // Testing
-  dependencies.mockito,
-  dependencies.scalatestPlay,
-  dependencies.elasticsearchContainer,
-  // Clients
-  dependencies.opencc4j,
-  dependencies.googleCloudClient,
-  // Metrics
-  dependencies.prometheusClient,
-  dependencies.prometheusHotspot
-)
-
-lazy val dtoDependencies = commonDependencies
-
-lazy val jobsDependencies = commonDependencies ++ log4jDependencies ++ Seq(
-  dependencies.sparkCore % "provided",
-  dependencies.sparkSql % "provided",
-  dependencies.sparkXml,
-  // S3 support
-  dependencies.hadoop,
-  dependencies.hadoopClient,
-  dependencies.hadoopAWS,
-  dependencies.awsJavaSDK
-)
 
 /*
  * Build

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,0 +1,165 @@
+import sbt._
+import Keys._
+import play.sbt.PlayImport.{guice, ws}
+
+/*
+ * Dependencies
+ */
+
+object Dependencies {
+  val scalatestVersion = "3.2.2"
+  val jacksonVersion = "2.11.3"
+  val log4jVersion = "2.14.0"
+  val elasticsearchVersion = "7.10.1"
+  val sparkVersion = "3.0.1"
+  val hadoopVersion = "2.7.4"
+  val prometheusVersion = "0.9.0"
+
+  // Testing
+  val scalactic = "org.scalactic" %% "scalactic" % scalatestVersion
+  val scalatest = "org.scalatest" %% "scalatest" % scalatestVersion
+  val scalatestPlay =
+    "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test
+  val mockito = "org.mockito" %% "mockito-scala" % "1.16.0" % Test
+  val elasticsearchContainer =
+    "org.testcontainers" % "elasticsearch" % "1.15.0"
+
+  // Language helpers
+  val cats = "org.typelevel" %% "cats-core" % "2.0.0"
+  val lombok = "org.projectlombok" % "lombok" % "1.18.16"
+
+  val log4jImplementation =
+    "org.apache.logging.log4j" % "log4j-slf4j-impl" % log4jVersion
+  val log4jApi = "org.apache.logging.log4j" % "log4j-api" % log4jVersion
+  val log4jCore = "org.apache.logging.log4j" % "log4j-core" % log4jVersion
+  val log4jJson =
+    "org.apache.logging.log4j" % "log4j-layout-template-json" % log4jVersion
+
+  val prometheusClient = "io.prometheus" % "simpleclient" % prometheusVersion
+  val prometheusCommon =
+    "io.prometheus" % "simpleclient_common" % prometheusVersion
+  val prometheusHotspot =
+    "io.prometheus" % "simpleclient_hotspot" % prometheusVersion
+
+  // Spark
+  val sparkCore =
+    "org.apache.spark" %% "spark-core" % sparkVersion
+  val sparkSql = "org.apache.spark" %% "spark-sql" % sparkVersion
+  val sparkXml = "com.databricks" %% "spark-xml" % "0.10.0"
+  val hadoop = "org.apache.hadoop" % "hadoop-common" % hadoopVersion
+  val hadoopClient = "org.apache.hadoop" % "hadoop-client" % hadoopVersion
+  val hadoopAWS = "org.apache.hadoop" % "hadoop-aws" % hadoopVersion
+  val awsJavaSDK = "com.amazonaws" % "aws-java-sdk" % "1.7.4"
+  // Enable this when it is build for scala 2.12 in main
+  // And remove our local version
+  //    val elasticsearchHadoop =
+  //      "org.elasticsearch" % "elasticsearch-hadoop" % elasticsearchVersion
+
+  // NLP tools
+  val opencc4j = "com.github.houbb" % "opencc4j" % "1.6.0"
+
+  // External clients
+  val elasticsearchHighLevelClient =
+    "org.elasticsearch.client" % "elasticsearch-rest-high-level-client" % elasticsearchVersion
+  val oslib = "com.lihaoyi" %% "os-lib" % "0.7.1"
+  val googleCloudClient =
+    "com.google.cloud" % "google-cloud-language" % "1.101.6"
+
+  // Hacks for guava incompatibility
+  val hadoopMapreduceClient =
+    "org.apache.hadoop" % "hadoop-mapreduce-client-core" % "2.7.2"
+
+  // Security related dependency upgrades below here
+  val jacksonScala =
+    "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion
+  val jacksonDatabind =
+    "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
+  val jacksonCore =
+    "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion
+  val htrace = "org.apache.htrace" % "htrace-core" % "4.0.0-incubating"
+  val avro = "org.apache.avro" % "avro" % "1.10.0"
+}
+
+object ProjectDependencies {
+
+  val commonDependencies = Seq(
+    Dependencies.scalatest % "test",
+    Dependencies.scalactic,
+    Dependencies.cats,
+    ws
+  )
+
+  val log4jDependencies = Seq(
+    Dependencies.log4jApi,
+    Dependencies.log4jCore,
+    Dependencies.log4jImplementation,
+    Dependencies.log4jJson
+  )
+
+  val playDependencies = Seq(
+    Dependencies.scalatestPlay,
+    Dependencies.mockito
+  )
+
+  val forcedDependencies = Seq(
+    Dependencies.hadoopMapreduceClient,
+    Dependencies.jacksonScala,
+    Dependencies.jacksonDatabind,
+    Dependencies.jacksonCore,
+    Dependencies.lombok,
+    Dependencies.htrace,
+    Dependencies.hadoop,
+    Dependencies.avro,
+    Dependencies.log4jApi,
+    Dependencies.log4jCore,
+    Dependencies.log4jImplementation,
+    Dependencies.log4jJson
+  )
+
+  val apiDependencies: Seq[ModuleID] =
+    commonDependencies ++ playDependencies ++ log4jDependencies ++ Seq(
+      Dependencies.prometheusClient,
+      Dependencies.prometheusHotspot,
+      Dependencies.prometheusCommon
+    )
+
+  val contentDependencies: Seq[ModuleID] = commonDependencies ++ Seq(
+    Dependencies.scalatestPlay,
+    Dependencies.opencc4j
+  )
+
+  val domainDependencies: Seq[ModuleID] = commonDependencies ++ Seq(
+    // Dependency injection
+    guice,
+    // Used to generate elasticsearch matchers
+    Dependencies.elasticsearchHighLevelClient,
+    Dependencies.oslib,
+    // Testing
+    Dependencies.mockito,
+    Dependencies.scalatestPlay,
+    Dependencies.elasticsearchContainer,
+    // Clients
+    Dependencies.opencc4j,
+    Dependencies.googleCloudClient,
+    // Metrics
+    Dependencies.prometheusClient,
+    Dependencies.prometheusHotspot
+  )
+
+  val dtoDependencies: Seq[ModuleID] = commonDependencies
+
+  val jobsDependencies: Seq[ModuleID] =
+    commonDependencies ++ log4jDependencies ++ Seq(
+      Dependencies.sparkCore % "provided",
+      Dependencies.sparkSql % "provided",
+      Dependencies.sparkXml,
+      // S3 support
+      Dependencies.hadoop,
+      Dependencies.hadoopClient,
+      Dependencies.hadoopAWS,
+      Dependencies.awsJavaSDK
+    )
+
+  val allDependencies: Seq[ModuleID] =
+    apiDependencies ++ contentDependencies ++ domainDependencies ++ dtoDependencies ++ jobsDependencies
+}


### PR DESCRIPTION
## Problem
Every version changes the build number in `build.sbt`. This means the dependencies image is always different, and needs to be rebuilt.

## Solution
Provide a dummy `build.sbt` file which does not contain the version, and doesn't change. Use this for building dependencies.

## Why?
Cuts a 3-5 minute step from every build, speeding up PR checks and deployments.