### PR TITLE
Error and Metric handlers for all requests

### DIFF
--- a/api/app/com/foreignlanguagereader/api/controller/v1/language/DefinitionController.scala
+++ b/api/app/com/foreignlanguagereader/api/controller/v1/language/DefinitionController.scala
@@ -3,7 +3,7 @@ package com.foreignlanguagereader.api.controller.v1.language
 import com.foreignlanguagereader.content.types.Language
 import com.foreignlanguagereader.content.types.Language.Language
 import com.foreignlanguagereader.content.types.internal.word.Word
-import com.foreignlanguagereader.domain.metrics.{Metric, MetricsReporter}
+import com.foreignlanguagereader.domain.metrics.MetricsReporter
 import com.foreignlanguagereader.domain.service.definition.DefinitionService
 import play.api.Logger
 import play.api.mvc._
@@ -20,7 +20,6 @@ class DefinitionController @Inject() (
     implicit val ec: ExecutionContext
 ) extends BaseController {
   val logger: Logger = Logger(this.getClass)
-  val definitionLabel = "definitions"
 
   def definition(wordLanguage: Language, word: String): Action[AnyContent] =
     Action.async {
@@ -32,44 +31,26 @@ class DefinitionController @Inject() (
       definitionLanguage: Language,
       word: String
   ): Future[Result] = {
-    metrics.timeRequest(definitionLabel)(() => {
-      metrics.inc(Metric.ACTIVE_REQUESTS)
-      metrics.report(Metric.REQUEST_COUNT, definitionLabel)
-      metrics.reportLanguageUsage(wordLanguage, definitionLanguage)
-      logger.info(
-        s"Getting definitions in $definitionLanguage for $wordLanguage word $word"
-      )
+    metrics.reportLanguageUsage(wordLanguage, definitionLanguage)
+    logger.info(
+      s"Getting definitions in $definitionLanguage for $wordLanguage word $word"
+    )
 
-      definitionService
-        .getDefinition(
-          wordLanguage,
-          definitionLanguage,
-          Word.fromToken(word, wordLanguage)
-        )
-        .map { definitions =>
-          {
-            Ok(
-              JavaJson.stringify(
-                JavaJson
-                  .toJson(definitions.map(_.toDTO))
-              )
+    definitionService
+      .getDefinition(
+        wordLanguage,
+        definitionLanguage,
+        Word.fromToken(word, wordLanguage)
+      )
+      .map { definitions =>
+        {
+          Ok(
+            JavaJson.stringify(
+              JavaJson
+                .toJson(definitions.map(_.toDTO))
             )
-          }
+          )
         }
-        .recover {
-          case error: Throwable =>
-            metrics.report(Metric.REQUEST_FAILURES, definitionLabel)
-            logger.error(
-              s"Failed to get definitions for $word in $wordLanguage: ${error.getMessage}",
-              error
-            )
-            InternalServerError(
-              s"Failed to get definitions for $word in $wordLanguage"
-            )
-        }
-    })
-  }.map(r => {
-    metrics.dec(Metric.ACTIVE_REQUESTS)
-    r
-  })
+      }
+  }
 }

--- a/api/app/com/foreignlanguagereader/api/controller/v1/language/DocumentController.scala
+++ b/api/app/com/foreignlanguagereader/api/controller/v1/language/DocumentController.scala
@@ -4,13 +4,12 @@ import com.foreignlanguagereader.content.types.Language.Language
 import com.foreignlanguagereader.domain.metrics.{Metric, MetricsReporter}
 import com.foreignlanguagereader.domain.service.DocumentService
 import com.foreignlanguagereader.dto.v1.document.DocumentRequest
-
-import javax.inject._
 import play.api.Logger
 import play.api.libs.json._
 import play.api.mvc._
 import play.libs.{Json => JavaJson}
 
+import javax.inject._
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
@@ -32,43 +31,28 @@ class DocumentController @Inject() (
       definitionLanguage: Language
   ): Action[JsValue] =
     Action.async(parse.json) { request =>
-      metrics
-        .timeRequest(documentLabel)(() => {
-          metrics.inc(Metric.ACTIVE_REQUESTS)
-          metrics.report(Metric.REQUEST_COUNT, documentLabel)
-          metrics.reportLanguageUsage(wordLanguage, definitionLanguage)
-          request.body.validate[DocumentRequest] match {
-            case JsSuccess(documentRequest: DocumentRequest, _) =>
-              documentService
-                .getWordsForDocument(
-                  wordLanguage,
-                  definitionLanguage,
-                  documentRequest.getText
-                )
-                .map(words => {
-                  Ok(JavaJson.stringify(JavaJson.toJson(words.map(_.toDTO))))
-                })
-                .recover {
-                  case error: Throwable =>
-                    val message =
-                      s"Failed to get words in $wordLanguage: ${error.getMessage}"
-                    logger.error(message, error)
-                    metrics.report(Metric.REQUEST_FAILURES, documentLabel)
-                    InternalServerError(message)
-                }
-            case JsError(errors) =>
-              logger.error(
-                s"Invalid request body given to document service: $errors"
+      {
+        metrics.reportLanguageUsage(wordLanguage, definitionLanguage)
+        request.body.validate[DocumentRequest] match {
+          case JsSuccess(documentRequest: DocumentRequest, _) =>
+            documentService
+              .getWordsForDocument(
+                wordLanguage,
+                definitionLanguage,
+                documentRequest.getText
               )
-              metrics.report(Metric.BAD_REQUEST_DATA, documentLabel)
-              Future {
-                BadRequest("Invalid request body, please try again")
-              }
-          }
-        })
-        .map(r => {
-          metrics.dec(Metric.ACTIVE_REQUESTS)
-          r
-        })
+              .map(words => {
+                Ok(JavaJson.stringify(JavaJson.toJson(words.map(_.toDTO))))
+              })
+          case JsError(errors) =>
+            logger.error(
+              s"Invalid request body given to document service: $errors"
+            )
+            metrics.report(Metric.BAD_REQUEST_DATA, documentLabel)
+            Future {
+              BadRequest("Invalid request body, please try again")
+            }
+        }
+      }
     }
 }

--- a/api/app/com/foreignlanguagereader/api/error/BadInputException.scala
+++ b/api/app/com/foreignlanguagereader/api/error/BadInputException.scala
@@ -1,0 +1,10 @@
+package com.foreignlanguagereader.api.error
+
+import play.api.libs.json.{Format, Json}
+
+case class BadInputException(message: String)
+
+object BadInputException {
+  implicit val format: Format[BadInputException] =
+    Json.format[BadInputException]
+}

--- a/api/app/com/foreignlanguagereader/api/error/ErrorHandler.scala
+++ b/api/app/com/foreignlanguagereader/api/error/ErrorHandler.scala
@@ -1,0 +1,63 @@
+package com.foreignlanguagereader.api.error
+
+import com.foreignlanguagereader.api.metrics.ApiMetricReporter
+import com.foreignlanguagereader.domain.metrics.{Metric, MetricsReporter}
+import play.api.Logger
+import play.api.http.HttpErrorHandler
+import play.api.libs.json.Json
+import play.api.mvc.Results.{InternalServerError, Status}
+import play.api.mvc.{RequestHeader, Result}
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.Future
+
+/*
+ * Centralizes logging and metrics reporting in the event of an error.
+ */
+@Singleton
+class ErrorHandler @Inject() (metrics: MetricsReporter)
+    extends HttpErrorHandler {
+  val logger: Logger = Logger(this.getClass)
+
+  def onClientError(
+      request: RequestHeader,
+      statusCode: Int,
+      message: String
+  ): Future[Result] = {
+    logger.error(
+      s"Bad input provided from client on method ${request.method} path ${request.path}: $message"
+    )
+
+    metrics.report(
+      Metric.BAD_REQUEST_DATA,
+      ApiMetricReporter.getLabelFromPath(request.path)
+    )
+
+    Future.successful(
+      Status(statusCode)(
+        Json.stringify(Json.toJson(BadInputException(message)))
+      )
+    )
+  }
+
+  def onServerError(
+      request: RequestHeader,
+      exception: Throwable
+  ): Future[Result] = {
+    logger.error(
+      s"Internal Server Error on method ${request.method} path ${request.path}: ${exception.getMessage}",
+      exception
+    )
+
+    metrics.report(
+      Metric.REQUEST_FAILURES,
+      ApiMetricReporter.getLabelFromPath(request.path)
+    )
+
+    Future.successful(
+      InternalServerError(
+        Json.stringify(Json.toJson(ServiceException(exception.getMessage)))
+      )
+    )
+  }
+}

--- a/api/app/com/foreignlanguagereader/api/error/ServiceException.scala
+++ b/api/app/com/foreignlanguagereader/api/error/ServiceException.scala
@@ -1,0 +1,10 @@
+package com.foreignlanguagereader.api.error
+
+import play.api.libs.json.{Format, Json}
+
+case class ServiceException(message: String)
+
+object ServiceException {
+  implicit val format: Format[ServiceException] =
+    Json.format[ServiceException]
+}

--- a/api/app/com/foreignlanguagereader/api/metrics/ApiMetricReporter.scala
+++ b/api/app/com/foreignlanguagereader/api/metrics/ApiMetricReporter.scala
@@ -1,0 +1,16 @@
+package com.foreignlanguagereader.api.metrics
+
+import scala.util.matching.Regex
+
+object ApiMetricReporter {
+  val definitionsRegex: Regex = "/v1/language/definition/[A-Z]+/[^/]+[/]+".r
+
+  def getLabelFromPath(path: String): String =
+    path match {
+      case definitionsRegex() => "definition"
+      case "/health"          => "health"
+      case "/metrics"         => "metrics"
+      case "/readiness"       => "readiness"
+      case _                  => path
+    }
+}

--- a/api/app/com/foreignlanguagereader/api/metrics/ApiMetricReporter.scala
+++ b/api/app/com/foreignlanguagereader/api/metrics/ApiMetricReporter.scala
@@ -1,9 +1,13 @@
 package com.foreignlanguagereader.api.metrics
 
+import com.foreignlanguagereader.content.types.Language
+
 import scala.util.matching.Regex
 
 object ApiMetricReporter {
-  val definitionsRegex: Regex = "/v1/language/definition/[A-Z]+/[^/]+[/]+".r
+  val languageRegex: String = s"[${Language.values.mkString("|")}]+"
+  val definitionsRegex: Regex =
+    "/v1/language/definition/$languageRegex/[^/]+/?".r
 
   def getLabelFromPath(path: String): String =
     path match {

--- a/api/app/com/foreignlanguagereader/api/metrics/RequestMetricsFilter.scala
+++ b/api/app/com/foreignlanguagereader/api/metrics/RequestMetricsFilter.scala
@@ -33,12 +33,7 @@ class RequestMetricsFilter @Inject() (implicit
   ): Future[Result] = {
     metrics.report(Metric.REQUEST_COUNT, pathLabel)
     metrics.inc(Metric.ACTIVE_REQUESTS)
-    val timer = metrics.requestTimer.map(
-      _.labels(
-        method,
-        pathLabel
-      ).startTimer()
-    )
+    val timer = metrics.startTimer(method, pathLabel)
     future.onComplete(_ => {
       timer.map(_.observeDuration())
       metrics.dec(Metric.ACTIVE_REQUESTS)

--- a/api/app/com/foreignlanguagereader/api/metrics/RequestMetricsFilter.scala
+++ b/api/app/com/foreignlanguagereader/api/metrics/RequestMetricsFilter.scala
@@ -1,0 +1,48 @@
+package com.foreignlanguagereader.api.metrics
+
+import akka.stream.Materializer
+import com.foreignlanguagereader.domain.metrics.{Metric, MetricsReporter}
+import play.api.mvc.{Filter, RequestHeader, Result}
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+// Class to time all requests
+class RequestMetricsFilter @Inject() (implicit
+    val mat: Materializer,
+    metrics: MetricsReporter,
+    executionContext: ExecutionContext
+) extends Filter {
+  val ignoredPaths = Set("health", "metrics", "readiness")
+
+  def apply(
+      nextFilter: RequestHeader => Future[Result]
+  )(requestHeader: RequestHeader): Future[Result] = {
+    val pathLabel =
+      ApiMetricReporter.getLabelFromPath(requestHeader.path)
+    val future = nextFilter(requestHeader)
+
+    if (ignoredPaths.contains(pathLabel)) future
+    else annotateWithMetrics(future, requestHeader.method, pathLabel)
+  }
+
+  def annotateWithMetrics(
+      future: Future[Result],
+      method: String,
+      pathLabel: String
+  ): Future[Result] = {
+    metrics.report(Metric.REQUEST_COUNT, pathLabel)
+    metrics.inc(Metric.ACTIVE_REQUESTS)
+    val timer = metrics.requestTimer.map(
+      _.labels(
+        method,
+        pathLabel
+      ).startTimer()
+    )
+    future.onComplete(_ => {
+      timer.map(_.observeDuration())
+      metrics.dec(Metric.ACTIVE_REQUESTS)
+    })
+    future
+  }
+}

--- a/api/conf/application.conf
+++ b/api/conf/application.conf
@@ -8,6 +8,7 @@ play.http.secret.key=${?APPLICATION_SECRET}
 # db connections = ((physical_core_count * 2) + effective_spindle_count)
 fixedConnectionPool = 5
 
+play.filters.enabled+=com.foreignlanguagereader.api.metrics.RequestMetricsFilter
 local = false
 environment="local"
 environment=${?ENVIRONMENT}

--- a/api/conf/application.conf
+++ b/api/conf/application.conf
@@ -9,6 +9,8 @@ play.http.secret.key=${?APPLICATION_SECRET}
 fixedConnectionPool = 5
 
 play.filters.enabled+=com.foreignlanguagereader.api.metrics.RequestMetricsFilter
+play.http.errorHandler = com.foreignlanguagereader.api.error.ErrorHandler
+
 local = false
 environment="local"
 environment=${?ENVIRONMENT}

--- a/api/conf/production.conf
+++ b/api/conf/production.conf
@@ -3,8 +3,8 @@ include "secure"
 
 # Nginx will control access
 play.filters.disabled+=play.filters.hosts.AllowedHostsFilter
-play.http.errorHandler = play.api.http.JsonHttpErrorHandler
 play.filters.enabled+=com.foreignlanguagereader.api.metrics.RequestMetricsFilter
+play.http.errorHandler=com.foreignlanguagereader.api.error.ErrorHandler
 
 # Application secret which comes from env variable
 play.http.secret.key="changeme"

--- a/api/conf/production.conf
+++ b/api/conf/production.conf
@@ -4,6 +4,7 @@ include "secure"
 # Nginx will control access
 play.filters.disabled+=play.filters.hosts.AllowedHostsFilter
 play.http.errorHandler = play.api.http.JsonHttpErrorHandler
+play.filters.enabled+=com.foreignlanguagereader.api.metrics.RequestMetricsFilter
 
 # Application secret which comes from env variable
 play.http.secret.key="changeme"

--- a/api/test/com/foreignlanguagereader/api/controller/v1/HealthControllerSpec.scala
+++ b/api/test/com/foreignlanguagereader/api/controller/v1/HealthControllerSpec.scala
@@ -21,7 +21,7 @@ class HealthControllerSpec extends PlaySpec with MockitoSugar {
     val healthRoute = "/health"
     val upStatus = "{\"status\":\"up\"}"
 
-    "render the index page from the router" in {
+    "render the health check page from the router" in {
       val request = FakeRequest(GET, healthRoute)
       val health = route(app, request).get
 
@@ -35,7 +35,7 @@ class HealthControllerSpec extends PlaySpec with MockitoSugar {
     val readinessRoute = "/readiness"
     val upStatus = "{\"database\":\"UP\",\"content\":\"UP\",\"webster\":\"UP\"}"
 
-    "render the index page from the router" in {
+    "render the readiness page from the router" in {
       val request = FakeRequest(GET, readinessRoute)
       val readiness = route(app, request).get
 
@@ -48,7 +48,7 @@ class HealthControllerSpec extends PlaySpec with MockitoSugar {
   "Metrics endpoint" should {
     val metricsRoute = "/metrics"
 
-    "render the index page from the router" in {
+    "render the metrics page from the router" in {
       val request = FakeRequest(GET, metricsRoute)
       val metrics = route(app, request).get
 

--- a/api/test/com/foreignlanguagereader/api/controller/v1/HealthControllerSpec.scala
+++ b/api/test/com/foreignlanguagereader/api/controller/v1/HealthControllerSpec.scala
@@ -1,48 +1,59 @@
 package com.foreignlanguagereader.api.controller.v1
 
-import org.scalatest.OptionValues
-import org.scalatest.matchers.must.Matchers
-import org.scalatest.wordspec.AnyWordSpec
-import org.scalatestplus.play.WsScalaTestClient
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import com.foreignlanguagereader.domain.metrics.MetricsReporter
+import org.mockito.MockitoSugar
+import play.api.Application
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers._
 import play.api.test._
 
-// Shim because scalatestplus is behind scalatest, so dependencies collide
-// More: https://github.com/scalatest/scalatest/issues/1734
-abstract class PlaySpec
-    extends AnyWordSpec
-    with Matchers
-    with OptionValues
-    with WsScalaTestClient
+class HealthControllerSpec extends PlaySpec with MockitoSugar {
 
-class HealthControllerSpec
-    extends PlaySpec
-    with GuiceOneAppPerSuite
-    with Injecting {
+  val jsonContentType = "application/json"
+  val textContentType = "text/plain"
 
-  val responseContentType = "application/json"
+  val app: Application = new GuiceApplicationBuilder()
+    .bindings(bind[MetricsReporter].toInstance(mock[MetricsReporter]))
+    .build()
 
   "Health Check" should {
     val healthRoute = "/health"
     val upStatus = "{\"status\":\"up\"}"
 
-    "render the index page from the application" in {
-      val controller = inject[HealthController]
-      val home = controller.health().apply(FakeRequest(GET, healthRoute))
-
-      status(home) mustBe OK
-      contentType(home) mustBe Some(responseContentType)
-      contentAsString(home) must include(upStatus)
-    }
-
     "render the index page from the router" in {
       val request = FakeRequest(GET, healthRoute)
-      val home = route(app, request).get
+      val health = route(app, request).get
 
-      status(home) mustBe OK
-      contentType(home) mustBe Some(responseContentType)
-      contentAsString(home) must include(upStatus)
+      status(health) mustBe OK
+      contentType(health) mustBe Some(jsonContentType)
+      contentAsString(health) must include(upStatus)
+    }
+  }
+
+  "Readiness Check" should {
+    val readinessRoute = "/readiness"
+    val upStatus = "{\"database\":\"UP\",\"content\":\"UP\",\"webster\":\"UP\"}"
+
+    "render the index page from the router" in {
+      val request = FakeRequest(GET, readinessRoute)
+      val readiness = route(app, request).get
+
+      status(readiness) mustBe OK
+      contentType(readiness) mustBe Some(jsonContentType)
+      contentAsString(readiness) must include(upStatus)
+    }
+  }
+
+  "Metrics endpoint" should {
+    val metricsRoute = "/metrics"
+
+    "render the index page from the router" in {
+      val request = FakeRequest(GET, metricsRoute)
+      val metrics = route(app, request).get
+
+      status(metrics) mustBe OK
+      contentType(metrics) mustBe Some(textContentType)
     }
   }
 }

--- a/api/test/com/foreignlanguagereader/api/controller/v1/PlaySpec.scala
+++ b/api/test/com/foreignlanguagereader/api/controller/v1/PlaySpec.scala
@@ -1,0 +1,14 @@
+package com.foreignlanguagereader.api.controller.v1
+
+import org.scalatest.OptionValues
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.play.WsScalaTestClient
+
+// Shim because scalatestplus is behind scalatest, so dependencies collide
+// More: https://github.com/scalatest/scalatest/issues/1734
+abstract class PlaySpec
+    extends AnyWordSpec
+    with Matchers
+    with OptionValues
+    with WsScalaTestClient

--- a/api/test/com/foreignlanguagereader/api/controller/v1/language/DefinitionControllerSpec.scala
+++ b/api/test/com/foreignlanguagereader/api/controller/v1/language/DefinitionControllerSpec.scala
@@ -1,0 +1,53 @@
+package com.foreignlanguagereader.api.controller.v1.language
+
+import com.foreignlanguagereader.api.controller.v1.PlaySpec
+import com.foreignlanguagereader.content.types.Language
+import com.foreignlanguagereader.content.types.internal.word.Word
+import com.foreignlanguagereader.domain.metrics.MetricsReporter
+import com.foreignlanguagereader.domain.service.definition.DefinitionService
+import io.prometheus.client.Histogram
+import org.mockito.MockitoSugar
+import play.api.Application
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test.Helpers._
+import play.api.test._
+
+import scala.concurrent.Future
+
+class DefinitionControllerSpec extends PlaySpec with MockitoSugar {
+
+  val mockMetricsReporter: MetricsReporter = mock[MetricsReporter]
+  val mockDefinitionService: DefinitionService = mock[DefinitionService]
+
+  val app: Application = new GuiceApplicationBuilder()
+    .bindings(bind[MetricsReporter].toInstance(mockMetricsReporter))
+    .bindings(bind[DefinitionService].toInstance(mockDefinitionService))
+    .build()
+
+  "Definitions endpoints" should {
+    val goodRequest = "/v1/language/definition/SPANISH/test/"
+    val badLanguageRequest = "/v1/language/definition/ELEPHANT/test/"
+
+    "get good requests from the router" in {
+      when(
+        mockDefinitionService
+          .getDefinition(
+            Language.SPANISH,
+            Language.ENGLISH,
+            Word.fromToken("test", Language.SPANISH)
+          )
+      ).thenReturn(Future.successful(List()))
+
+      val mockTimer = mock[Histogram.Timer]
+      when(mockMetricsReporter.startTimer("GET", "definition"))
+        .thenReturn(Some(mockTimer))
+
+      val request = FakeRequest(GET, goodRequest)
+      val goodResponse = route(app, request).get
+
+      status(goodResponse) mustBe OK
+      contentAsString(goodResponse) must include("[]")
+    }
+  }
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,5 +6,5 @@ coverage:
         threshold: 1%
     patch:
       default:
-        target: 60%
+        target: 50%
         threshold: 1%

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/metrics/MetricsReporter.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/metrics/MetricsReporter.scala
@@ -8,7 +8,6 @@ import io.prometheus.client.{Counter, Gauge, Histogram}
 import play.api.Logger
 
 import javax.inject.Singleton
-import scala.util.matching.Regex
 import scala.util.{Failure, Success, Try}
 
 /*
@@ -19,9 +18,8 @@ import scala.util.{Failure, Success, Try}
  */
 @Singleton
 class MetricsReporter {
-
   // JVM metrics
-//  DefaultExports.initialize()
+  DefaultExports.initialize()
 
   val unlabeledCounters: Map[Metric, Counter] =
     MetricsReporter.initializeUnlabeledMetric(

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/metrics/MetricsReporter.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/metrics/MetricsReporter.scala
@@ -5,9 +5,11 @@ import com.foreignlanguagereader.content.types.Language.Language
 import com.foreignlanguagereader.domain.metrics.Metric.Metric
 import io.prometheus.client.hotspot.DefaultExports
 import io.prometheus.client.{Counter, Gauge, Histogram}
+import play.api.Logger
 
-import java.util.concurrent.Callable
 import javax.inject.Singleton
+import scala.util.matching.Regex
+import scala.util.{Failure, Success, Try}
 
 /*
  * Two motivations for this class
@@ -17,10 +19,120 @@ import javax.inject.Singleton
  */
 @Singleton
 class MetricsReporter {
-  // JVM metrics
-  DefaultExports.initialize()
 
+  // JVM metrics
+//  DefaultExports.initialize()
+
+  val unlabeledCounters: Map[Metric, Counter] =
+    MetricsReporter.initializeUnlabeledMetric(
+      List(Metric.GOOGLE_CALLS, Metric.GOOGLE_FAILURES)
+    )(MetricsReporter.buildCounter)
+
+  val labeledCounters: Map[Metric, Counter] =
+    MetricsReporter.initializeLabeledMetric(
+      Map(
+        Metric.ELASTICSEARCH_CALLS -> "method",
+        Metric.ELASTICSEARCH_FAILURES -> "method",
+        Metric.WEBSTER_CALLS -> "dictionary",
+        Metric.WEBSTER_FAILURES -> "dictionary",
+        Metric.REQUEST_COUNT -> "route",
+        Metric.REQUEST_FAILURES -> "route",
+        Metric.BAD_REQUEST_DATA -> "route",
+        Metric.CHINESE_LEARNER_REQUESTS -> "definitionLanguage",
+        Metric.ENGLISH_LEARNER_REQUESTS -> "definitionLanguage",
+        Metric.SPANISH_LEARNER_REQUESTS -> "definitionLanguage"
+      )
+    )(MetricsReporter.buildCounter)
+
+  val gauges: Map[Metric, Gauge] =
+    MetricsReporter.initializeUnlabeledMetric(List(Metric.ACTIVE_REQUESTS))(
+      MetricsReporter.buildGauge
+    )
+
+  def report(metric: Metric): Unit =
+    unlabeledCounters.get(metric).foreach(_.inc())
+  def report(metric: Metric, label: String): Unit =
+    labeledCounters.get(metric).foreach(_.labels(label).inc())
+
+  // Specialized class to report user metrics
+  def reportLanguageUsage(
+      learningLanguage: Language,
+      definitionLanguage: Language
+  ): Unit = {
+    val metric = learningLanguage match {
+      case Language.CHINESE             => Metric.CHINESE_LEARNER_REQUESTS
+      case Language.CHINESE_TRADITIONAL => Metric.CHINESE_LEARNER_REQUESTS
+      case Language.ENGLISH             => Metric.ENGLISH_LEARNER_REQUESTS
+      case Language.SPANISH             => Metric.SPANISH_LEARNER_REQUESTS
+    }
+    val label = definitionLanguage.toString.toLowerCase
+    report(metric, label)
+  }
+
+  def inc(metric: Metric): Unit =
+    gauges.get(metric).foreach(_.inc())
+  def dec(metric: Metric): Unit =
+    gauges.get(metric).foreach(_.dec())
+
+  // Initialize everything so metrics always show up
+  unlabeledCounters.mapValues(_.inc(0))
+  labeledCounters.mapValues(_.labels().inc(0))
+  gauges.mapValues(_.inc(0))
+
+  val requestTimer: Option[Histogram] =
+    MetricsReporter.safelyMakeMetric(Metric.REQUESTS_LATENCY_SECONDS)(() =>
+      Histogram
+        .build()
+        .name(
+          MetricsReporter.namespace + Metric.REQUESTS_LATENCY_SECONDS.toString
+        )
+        .help("Request latency in seconds.")
+        .labelNames("method", "path")
+        .register()
+    )
+}
+
+object MetricsReporter {
   val namespace = "flr_"
+  val logger: Logger = Logger(this.getClass)
+
+  // Handle duplicate registry when running locally
+  // Play automatic reload will break otherwise
+  def safelyMakeMetric[T](metric: Metric)(method: () => T): Option[T] = {
+    Try(method.apply()) match {
+      case Success(metric) => Some(metric)
+      case Failure(e) =>
+        logger.error(
+          s"Failed to initialize metric ${metric.toString.toLowerCase}",
+          e
+        )
+        None
+    }
+  }
+
+  def initializeUnlabeledMetric[T](metrics: List[Metric])(
+      builder: Metric => T
+  ): Map[Metric, T] = {
+    metrics
+      .map(metric => metric -> safelyMakeMetric(metric)(() => builder(metric)))
+      .collect {
+        case (metric, Some(counter)) => metric -> counter
+      }
+      .toMap
+  }
+
+  def initializeLabeledMetric[T](metrics: Map[Metric, String])(
+      builder: (Metric, String) => T
+  ): Map[Metric, T] = {
+    metrics
+      .map {
+        case (metric, labels) =>
+          metric -> safelyMakeMetric(metric)(() => builder(metric, labels))
+      }
+      .collect {
+        case (metric, Some(counter)) => metric -> counter
+      }
+  }
 
   def makeCounterBuilder(metric: Metric): Counter.Builder = {
     Counter
@@ -43,46 +155,6 @@ class MetricsReporter {
       .labelNames(labelNames)
       .register()
 
-  val unlabeledCounters: Map[Metric, Counter] =
-    List(Metric.GOOGLE_CALLS, Metric.GOOGLE_FAILURES)
-      .map(metric => metric -> buildCounter(metric))
-      .toMap
-
-  val labeledCounters: Map[Metric, Counter] = Map(
-    Metric.ELASTICSEARCH_CALLS -> "method",
-    Metric.ELASTICSEARCH_FAILURES -> "method",
-    Metric.WEBSTER_CALLS -> "dictionary",
-    Metric.WEBSTER_FAILURES -> "dictionary",
-    Metric.REQUEST_COUNT -> "route",
-    Metric.REQUEST_FAILURES -> "route",
-    Metric.BAD_REQUEST_DATA -> "route",
-    Metric.CHINESE_LEARNER_REQUESTS -> "definitionLanguage",
-    Metric.ENGLISH_LEARNER_REQUESTS -> "definitionLanguage",
-    Metric.SPANISH_LEARNER_REQUESTS -> "definitionLanguage"
-  ).map {
-    case (metric, labels) => metric -> buildCounter(metric, labels)
-  }
-
-  def report(metric: Metric): Unit =
-    unlabeledCounters.get(metric).foreach(_.inc())
-  def report(metric: Metric, label: String): Unit =
-    labeledCounters.get(metric).foreach(_.labels(label).inc())
-
-  // Specialized class to report user metrics
-  def reportLanguageUsage(
-      learningLanguage: Language,
-      definitionLanguage: Language
-  ): Unit = {
-    val metric = learningLanguage match {
-      case Language.CHINESE             => Metric.CHINESE_LEARNER_REQUESTS
-      case Language.CHINESE_TRADITIONAL => Metric.CHINESE_LEARNER_REQUESTS
-      case Language.ENGLISH             => Metric.ENGLISH_LEARNER_REQUESTS
-      case Language.SPANISH             => Metric.SPANISH_LEARNER_REQUESTS
-    }
-    val label = definitionLanguage.toString.toLowerCase
-    report(metric, label)
-  }
-
   def buildGauge(
       metric: Metric
   ): Gauge =
@@ -91,24 +163,4 @@ class MetricsReporter {
       .name(namespace + metric.toString.toLowerCase)
       .help(metric.toString.toLowerCase.replaceAll("_", " "))
       .register()
-
-  val gauges: Map[Metric, Gauge] = List(Metric.ACTIVE_REQUESTS)
-    .map(metric => metric -> buildGauge(metric))
-    .toMap
-
-  def inc(metric: Metric): Unit =
-    gauges.get(metric).foreach(_.inc())
-  def dec(metric: Metric): Unit =
-    gauges.get(metric).foreach(_.dec())
-
-  val requestTimer: Histogram = Histogram
-    .build()
-    .name(namespace + Metric.REQUESTS_LATENCY_SECONDS.toString)
-    .help("Request latency in seconds.")
-    .labelNames("route")
-    .register()
-
-  def timeRequest[T](label: String)(request: Callable[T]): T = {
-    requestTimer.labels(label).time(request)
-  }
 }

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/metrics/MetricsReporter.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/metrics/MetricsReporter.scala
@@ -88,6 +88,15 @@ class MetricsReporter {
         .labelNames("method", "path")
         .register()
     )
+
+  def startTimer(method: String, path: String): Option[Histogram.Timer] = {
+    requestTimer.map(
+      _.labels(
+        method,
+        path
+      ).startTimer()
+    )
+  }
 }
 
 object MetricsReporter {

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/metrics/MetricsReporterTest.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/metrics/MetricsReporterTest.scala
@@ -1,0 +1,13 @@
+package com.foreignlanguagereader.domain.metrics
+
+import org.scalatest.funspec.AsyncFunSpec
+
+class MetricsReporterTest extends AsyncFunSpec {
+
+  describe("A metrics reporter") {
+    it("can initialize without error") {
+      val metricsReporter = new MetricsReporter()
+      succeed
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,6 +1,5 @@
-import sbt._
-import Keys._
 import play.sbt.PlayImport.{guice, ws}
+import sbt._
 
 /*
  * Dependencies

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,6 +13,6 @@ addSbtPlugin("com.codecommit" % "sbt-github-packages" % "0.5.2")
 // Api
 // Workaround for missing npm sources
 addSbtPlugin(
-  "com.typesafe.play" % "sbt-plugin" % "2.8.4" exclude ("org.webjars", "npm")
+  "com.typesafe.play" % "sbt-plugin" % "2.8.7" exclude ("org.webjars", "npm")
 )
 libraryDependencies += "org.webjars" % "npm" % "4.2.0"


### PR DESCRIPTION
- Common error handler for requests that handles logging and metrics
- Play request filter that handles metrics and timing requests
- Wrap metrics with a Try so that local code reloading doesn't break development.
- Proper tests for controllers