### PR TITLE
Constrain metric labels

### DIFF
--- a/api/app/com/foreignlanguagereader/api/controller/v1/language/DefinitionController.scala
+++ b/api/app/com/foreignlanguagereader/api/controller/v1/language/DefinitionController.scala
@@ -31,7 +31,7 @@ class DefinitionController @Inject() (
       definitionLanguage: Language,
       word: String
   ): Future[Result] = {
-    metrics.reportLanguageUsage(wordLanguage, definitionLanguage)
+    metrics.reportLearnerLanguage(wordLanguage, definitionLanguage)
     logger.info(
       s"Getting definitions in $definitionLanguage for $wordLanguage word $word"
     )

--- a/api/app/com/foreignlanguagereader/api/controller/v1/language/DocumentController.scala
+++ b/api/app/com/foreignlanguagereader/api/controller/v1/language/DocumentController.scala
@@ -1,7 +1,8 @@
 package com.foreignlanguagereader.api.controller.v1.language
 
 import com.foreignlanguagereader.content.types.Language.Language
-import com.foreignlanguagereader.domain.metrics.{Metric, MetricsReporter}
+import com.foreignlanguagereader.domain.metrics.MetricsReporter
+import com.foreignlanguagereader.domain.metrics.label.RequestPath
 import com.foreignlanguagereader.domain.service.DocumentService
 import com.foreignlanguagereader.dto.v1.document.DocumentRequest
 import play.api.Logger
@@ -32,7 +33,7 @@ class DocumentController @Inject() (
   ): Action[JsValue] =
     Action.async(parse.json) { request =>
       {
-        metrics.reportLanguageUsage(wordLanguage, definitionLanguage)
+        metrics.reportLearnerLanguage(wordLanguage, definitionLanguage)
         request.body.validate[DocumentRequest] match {
           case JsSuccess(documentRequest: DocumentRequest, _) =>
             documentService
@@ -48,7 +49,7 @@ class DocumentController @Inject() (
             logger.error(
               s"Invalid request body given to document service: $errors"
             )
-            metrics.report(Metric.BAD_REQUEST_DATA, documentLabel)
+            metrics.reportBadRequest(RequestPath.DOCUMENT)
             Future {
               BadRequest("Invalid request body, please try again")
             }

--- a/api/app/com/foreignlanguagereader/api/error/ErrorHandler.scala
+++ b/api/app/com/foreignlanguagereader/api/error/ErrorHandler.scala
@@ -1,7 +1,7 @@
 package com.foreignlanguagereader.api.error
 
 import com.foreignlanguagereader.api.metrics.ApiMetricReporter
-import com.foreignlanguagereader.domain.metrics.{Metric, MetricsReporter}
+import com.foreignlanguagereader.domain.metrics.MetricsReporter
 import play.api.Logger
 import play.api.http.HttpErrorHandler
 import play.api.libs.json.Json
@@ -28,10 +28,7 @@ class ErrorHandler @Inject() (metrics: MetricsReporter)
       s"Bad input provided from client on method ${request.method} path ${request.path}: $message"
     )
 
-    metrics.report(
-      Metric.BAD_REQUEST_DATA,
-      ApiMetricReporter.getLabelFromPath(request.path)
-    )
+    metrics.reportBadRequest(ApiMetricReporter.getLabelFromPath(request.path))
 
     Future.successful(
       Status(statusCode)(
@@ -49,8 +46,7 @@ class ErrorHandler @Inject() (metrics: MetricsReporter)
       exception
     )
 
-    metrics.report(
-      Metric.REQUEST_FAILURES,
+    metrics.reportRequestFailure(
       ApiMetricReporter.getLabelFromPath(request.path)
     )
 

--- a/api/app/com/foreignlanguagereader/api/metrics/ApiMetricReporter.scala
+++ b/api/app/com/foreignlanguagereader/api/metrics/ApiMetricReporter.scala
@@ -1,20 +1,22 @@
 package com.foreignlanguagereader.api.metrics
 
 import com.foreignlanguagereader.content.types.Language
+import com.foreignlanguagereader.domain.metrics.label.RequestPath
+import com.foreignlanguagereader.domain.metrics.label.RequestPath.RequestPath
 
 import scala.util.matching.Regex
 
 object ApiMetricReporter {
   val languageRegex: String = s"[${Language.values.mkString("|")}]+"
   val definitionsRegex: Regex =
-    "/v1/language/definition/$languageRegex/[^/]+/?".r
+    s"/v1/language/definition/$languageRegex/[^/]+/?".r
 
-  def getLabelFromPath(path: String): String =
+  def getLabelFromPath(path: String): RequestPath =
     path match {
-      case definitionsRegex() => "definition"
-      case "/health"          => "health"
-      case "/metrics"         => "metrics"
-      case "/readiness"       => "readiness"
-      case _                  => path
+      case definitionsRegex() => RequestPath.DEFINITIONS
+      case "/health"          => RequestPath.HEALTH
+      case "/metrics"         => RequestPath.METRICS
+      case "/readiness"       => RequestPath.READINESS
+      case _                  => RequestPath.UNKNOWN
     }
 }

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/client/MirriamWebsterClient.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/client/MirriamWebsterClient.scala
@@ -11,8 +11,8 @@ import com.foreignlanguagereader.domain.client.common.{
   RestClient,
   RestClientBuilder
 }
+import com.foreignlanguagereader.domain.metrics.MetricsReporter
 import com.foreignlanguagereader.domain.metrics.label.WebsterDictionary
-import com.foreignlanguagereader.domain.metrics.{Metric, MetricsReporter}
 import com.foreignlanguagereader.dto.v1.health.ReadinessStatus.ReadinessStatus
 import play.api.libs.json.Reads
 import play.api.{Configuration, Logger}
@@ -52,7 +52,6 @@ class MirriamWebsterClient @Inject() (
 
   // TODO filter garbage
 
-  val learnersLabel = "learners"
   def getLearnersDefinition(
       word: Word
   ): Future[CircuitBreakerResult[List[WebsterLearnersDefinitionEntry]]] = {
@@ -72,7 +71,6 @@ class MirriamWebsterClient @Inject() (
     result
   }
 
-  val spanishLabel = "spanish"
   def getSpanishDefinition(
       word: Word
   ): Future[CircuitBreakerResult[List[WebsterSpanishDefinitionEntry]]] = {

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/DefinitionFetcher.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/fetcher/DefinitionFetcher.scala
@@ -38,10 +38,7 @@ trait DefinitionFetcher[T <: DefinitionEntry, U <: Definition] {
       source: DefinitionSource,
       word: Word
   )(implicit ec: ExecutionContext, tag: ClassTag[T]): Future[List[U]] = {
-    metrics.report(
-      Metric.DEFINITIONS_SEARCHED_IN_CACHE,
-      source.toString.toLowerCase
-    )
+    metrics.reportDefinitionsSearchedInCache(source)
     elasticsearch
       .findFromCacheOrRefetch(
         makeDefinitionRequest(
@@ -68,10 +65,7 @@ trait DefinitionFetcher[T <: DefinitionEntry, U <: Definition] {
       word: Word
   )(implicit ec: ExecutionContext): ElasticsearchSearchRequest[T] = {
     val fetcher = () => {
-      metrics.report(
-        Metric.DEFINITIONS_NOT_FOUND_IN_CACHE,
-        source.toString.toLowerCase
-      )
+      metrics.reportDefinitionsNotFoundInCache(source)
       fetch(definitionLanguage, word)
     }
 

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/metrics/Metric.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/metrics/Metric.scala
@@ -1,49 +1,64 @@
 package com.foreignlanguagereader.domain.metrics
 
-// $COVERAGE-OFF$
 object Metric extends Enumeration {
   type Metric = Value
 
-  // Latency - Duration
-  // Can this be attached as an interceptor?
-  val REQUESTS_LATENCY_SECONDS: Value = Value("requests_latency_seconds")
+  /*
+   * End user RED metrics
+   */
 
-  // Traffic - Rates
-  // Can this be attached as an interceptor?
+  // Requests
   val REQUEST_COUNT: Value = Value("request_count")
+  val ACTIVE_REQUESTS: Value = Value("active_requests")
 
   // Errors
   val REQUEST_FAILURES: Value = Value("request_failures")
   val BAD_REQUEST_DATA: Value =
     Value("bad_request_data") // Likely indicates issues on the frontend
 
-  // Clients
+  // Duration
+  val REQUESTS_LATENCY_SECONDS: Value = Value("requests_latency_seconds")
+
+  /*
+   * Downstream dependency RED metrics
+   */
+
+  // Requests
   val ELASTICSEARCH_CALLS: Value = Value("elasticsearch_calls")
-  val ELASTICSEARCH_FAILURES: Value = Value("elasticsearch_failures")
+  val ACTIVE_ELASTICSEARCH_REQUESTS: Value = Value(
+    "active_elasticsearch_requests"
+  )
   val GOOGLE_CALLS: Value = Value("google_calls")
-  val GOOGLE_FAILURES: Value = Value("google_failures")
+  val ACTIVE_GOOGLE_REQUESTS: Value = Value("active_google_requests")
   val WEBSTER_CALLS: Value = Value("webster_calls")
+  val ACTIVE_WEBSTER_REQUESTS: Value = Value("active_webster_requests")
+
+  // Errors
+  val ELASTICSEARCH_FAILURES: Value = Value("elasticsearch_failures")
+  val GOOGLE_FAILURES: Value = Value("google_failures")
   val WEBSTER_FAILURES: Value = Value("webster_failures")
 
-  // Saturation
-  val ACTIVE_REQUESTS: Value = Value("active_requests")
+  // Duration
+  val ELASTICSEARCH_LATENCY_SECONDS: Value = Value(
+    "elasticsearch_latency_seconds"
+  )
+  val GOOGLE_LATENCY_SECONDS: Value = Value("google_latency_seconds")
+  val WEBSTER_LATENCY_SECONDS: Value = Value("webster_latency_seconds")
 
-  // Usage metrics
-  val CHINESE_LEARNER_REQUESTS: Value =
-    Value("chinese_learner_requests") // label by definition language
-  val ENGLISH_LEARNER_REQUESTS: Value =
-    Value("english_learner_requests") // label by definition language
-  val SPANISH_LEARNER_REQUESTS: Value =
-    Value("spanish_learner_requests") // label by definition language
+  /*
+   * User behavior metrics
+   */
 
-  // Caching results
-  val DEFINITIONS_SEARCHED: Value =
-    Value("definitions_searched") // label by language
+  val LEARNER_LANGUAGE_REQUESTS: Value = Value("learner_language_requests")
+  val DEFINITIONS_SEARCHED: Value = Value("definitions_searched")
+
+  /*
+   * Caching metrics
+   */
   val DEFINITIONS_NOT_FOUND: Value =
-    Value("definitions_not_found") // label by language
+    Value("definitions_not_found")
   val DEFINITIONS_SEARCHED_IN_CACHE: Value =
-    Value("definitions_searched_in_cache") // label by source
+    Value("definitions_searched_in_cache")
   val DEFINITIONS_NOT_FOUND_IN_CACHE: Value =
-    Value("definitions_not_found_in_cache") // label by source
+    Value("definitions_not_found_in_cache")
 }
-// $COVERAGE-ON$

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/metrics/MetricHolder.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/metrics/MetricHolder.scala
@@ -1,0 +1,171 @@
+package com.foreignlanguagereader.domain.metrics
+
+import com.foreignlanguagereader.content.types.Language
+import com.foreignlanguagereader.domain.metrics.Metric.Metric
+import com.foreignlanguagereader.domain.metrics.label.{
+  ElasticsearchMethod,
+  RequestPath,
+  WebsterDictionary
+}
+import io.prometheus.client.{Counter, Gauge, Histogram}
+import play.api.Logger
+
+import javax.inject.Singleton
+import scala.util.{Failure, Success, Try}
+
+/*
+ * Two motivations for this class
+ * - Put an interface on metrics, in case we want to change solutions. Metrics design is still in an early stage
+ * - Metrics are global and shared among all instances. Creating one twice causes an error.
+ *      This makes creating metrics in classes play badly in tests, so we use this class that can be stubbed.
+ */
+@Singleton
+class MetricHolder {
+  val unlabeledCounters: Map[Metric, Counter] =
+    MetricHolder.initializeUnlabeledMetric(
+      List(Metric.GOOGLE_CALLS, Metric.GOOGLE_FAILURES)
+    )(MetricHolder.buildCounter)
+
+  val labeledCounters: Map[Metric, Counter] =
+    MetricHolder.initializeLabeledMetric(
+      Map(
+        Metric.ELASTICSEARCH_CALLS -> List("method"),
+        Metric.ELASTICSEARCH_FAILURES -> List("method"),
+        Metric.WEBSTER_CALLS -> List("dictionary"),
+        Metric.WEBSTER_FAILURES -> List("dictionary"),
+        Metric.REQUEST_COUNT -> List("route"),
+        Metric.REQUEST_FAILURES -> List("route"),
+        Metric.BAD_REQUEST_DATA -> List("route"),
+        Metric.LEARNER_LANGUAGE_REQUESTS -> List(
+          "learningLanguage",
+          "baseLanguage"
+        ),
+        Metric.DEFINITIONS_SEARCHED -> List("source"),
+        Metric.DEFINITIONS_NOT_FOUND -> List("source"),
+        Metric.DEFINITIONS_SEARCHED_IN_CACHE -> List("source"),
+        Metric.DEFINITIONS_NOT_FOUND_IN_CACHE -> List("source")
+      )
+    )(MetricHolder.buildCounter)
+
+  val gauges: Map[Metric, Gauge] =
+    MetricHolder.initializeUnlabeledMetric(
+      List(
+        Metric.ACTIVE_REQUESTS,
+        Metric.ACTIVE_ELASTICSEARCH_REQUESTS,
+        Metric.ACTIVE_GOOGLE_REQUESTS,
+        Metric.ACTIVE_WEBSTER_REQUESTS
+      )
+    )(
+      MetricHolder.buildGauge
+    )
+
+  val timers: Map[Metric, Histogram] =
+    MetricHolder.initializeLabeledMetric(
+      Map(
+        Metric.REQUESTS_LATENCY_SECONDS -> List("method", "path"),
+        Metric.ELASTICSEARCH_LATENCY_SECONDS -> List("action"),
+        Metric.GOOGLE_LATENCY_SECONDS -> List("api"),
+        Metric.WEBSTER_LATENCY_SECONDS -> List("dictionary")
+      )
+    )(MetricHolder.buildTimer)
+
+  def report(metric: Metric): Unit =
+    unlabeledCounters.get(metric).foreach(_.inc())
+  def report(metric: Metric, labels: Seq[String]): Unit =
+    labeledCounters.get(metric).foreach(_.labels(labels: _*).inc())
+  def report(metric: Metric, label: String): Unit = report(metric, List(label))
+
+  def inc(metric: Metric): Unit =
+    gauges.get(metric).foreach(_.inc())
+  def dec(metric: Metric): Unit =
+    gauges.get(metric).foreach(_.dec())
+
+  def startTimer(
+      metric: Metric,
+      labels: Seq[String]
+  ): Option[Histogram.Timer] = {
+    timers.get(metric).map(timer => timer.labels(labels: _*).startTimer())
+  }
+}
+
+object MetricHolder {
+  val namespace = "flr_"
+  val logger: Logger = Logger(this.getClass)
+
+  // Handle duplicate registry when running locally
+  // Play automatic reload will break otherwise
+  def safelyMakeMetric[T](metric: Metric)(method: () => T): Option[T] = {
+    Try(method.apply()) match {
+      case Success(metric) => Some(metric)
+      case Failure(e) =>
+        logger.error(
+          s"Failed to initialize metric ${metric.toString.toLowerCase}",
+          e
+        )
+        None
+    }
+  }
+
+  def initializeUnlabeledMetric[T](metrics: List[Metric])(
+      builder: Metric => T
+  ): Map[Metric, T] = {
+    metrics
+      .map(metric => metric -> safelyMakeMetric(metric)(() => builder(metric)))
+      .collect {
+        case (metric, Some(counter)) => metric -> counter
+      }
+      .toMap
+  }
+
+  def initializeLabeledMetric[T](metrics: Map[Metric, Seq[String]])(
+      builder: (Metric, Seq[String]) => T
+  ): Map[Metric, T] = {
+    metrics
+      .map {
+        case (metric, labels) =>
+          metric -> safelyMakeMetric(metric)(() => builder(metric, labels))
+      }
+      .collect {
+        case (metric, Some(counter)) => metric -> counter
+      }
+  }
+
+  def makeCounterBuilder(metric: Metric): Counter.Builder = {
+    Counter
+      .build()
+      .name(namespace + metric.toString.toLowerCase)
+      .help(metric.toString.toLowerCase.replaceAll("_", " "))
+  }
+
+  def buildCounter(
+      metric: Metric
+  ): Counter =
+    makeCounterBuilder(metric)
+      .register()
+
+  def buildCounter(
+      metric: Metric,
+      labelNames: Seq[String]
+  ): Counter =
+    makeCounterBuilder(metric)
+      .labelNames(labelNames: _*)
+      .register()
+
+  def buildGauge(
+      metric: Metric
+  ): Gauge =
+    Gauge
+      .build()
+      .name(namespace + metric.toString.toLowerCase)
+      .help(metric.toString.toLowerCase.replaceAll("_", " "))
+      .register()
+
+  def buildTimer(metric: Metric, labelNames: Seq[String]): Histogram =
+    Histogram
+      .build()
+      .name(namespace + metric.toString)
+      .help(metric.toString.toLowerCase.replaceAll("_", " "))
+      .labelNames(labelNames: _*)
+      .register()
+
+}

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/metrics/label/ElasticsearchMethod.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/metrics/label/ElasticsearchMethod.scala
@@ -1,0 +1,10 @@
+package com.foreignlanguagereader.domain.metrics.label
+
+object ElasticsearchMethod extends Enumeration {
+  type ElasticsearchMethod = Value
+
+  val BULK: Value = Value("bulk")
+  val INDEX: Value = Value("index")
+  val MULTISEARCH: Value = Value("multisearch")
+  val SEARCH: Value = Value("search")
+}

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/metrics/label/RequestPath.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/metrics/label/RequestPath.scala
@@ -1,0 +1,12 @@
+package com.foreignlanguagereader.domain.metrics.label
+
+object RequestPath extends Enumeration {
+  type RequestPath = Value
+
+  val DEFINITIONS: Value = Value("definition")
+  val DOCUMENT: Value = Value("document")
+  val HEALTH: Value = Value("health")
+  val METRICS: Value = Value("metrics")
+  val READINESS: Value = Value("readiness")
+  val UNKNOWN: Value = Value("unknown")
+}

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/metrics/label/WebsterDictionary.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/metrics/label/WebsterDictionary.scala
@@ -1,0 +1,8 @@
+package com.foreignlanguagereader.domain.metrics.label
+
+object WebsterDictionary extends Enumeration {
+  type WebsterDictionary = Value
+
+  val LEARNERS: Value = Value("learners")
+  val SPANISH: Value = Value("spanish")
+}

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/metrics/MetricsHolderTest.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/metrics/MetricsHolderTest.scala
@@ -1,12 +1,31 @@
 package com.foreignlanguagereader.domain.metrics
 
+import com.foreignlanguagereader.content.types.internal.definition.DefinitionSource
+import com.foreignlanguagereader.domain.metrics.Metric.Metric
+import com.foreignlanguagereader.domain.metrics.label.{
+  ElasticsearchMethod,
+  RequestPath,
+  WebsterDictionary
+}
 import org.mockito.MockitoSugar
 import org.scalatest.funspec.AsyncFunSpec
 
 class MetricsHolderTest extends AsyncFunSpec with MockitoSugar {
 
+  def testMetricValues(metric: Metric, labels: Set[String])(implicit
+      holder: MetricHolder
+  ): Unit = {
+    labels.foreach(label => {
+      val count = holder.labeledCounters
+        .get(metric)
+        .map(_.labels(label).get())
+        .getOrElse(-1)
+      assert(count == 0, s"Metric $metric, $label was not zero")
+    })
+  }
+
   describe("A metrics holder") {
-    val holder = new MetricHolder()
+    implicit val holder: MetricHolder = new MetricHolder()
 
     it("creates a counter for every metric") {
       val initializedMetrics =
@@ -18,5 +37,61 @@ class MetricsHolderTest extends AsyncFunSpec with MockitoSugar {
       succeed
     }
 
+    it("initializes every metric") {
+      holder.initializeMetricsToZero()
+      holder.unlabeledCounters.foreach {
+        case (_, counter) => assert(counter.get() == 0)
+      }
+      holder.gauges.foreach {
+        case (_, gauge) => assert(gauge.get() == 0)
+      }
+
+      testMetricValues(
+        Metric.ELASTICSEARCH_CALLS,
+        ElasticsearchMethod.values.map(_.toString)
+      )
+      testMetricValues(
+        Metric.ELASTICSEARCH_FAILURES,
+        ElasticsearchMethod.values.map(_.toString)
+      )
+      testMetricValues(
+        Metric.WEBSTER_CALLS,
+        WebsterDictionary.values.map(_.toString)
+      )
+      testMetricValues(
+        Metric.WEBSTER_FAILURES,
+        WebsterDictionary.values.map(_.toString)
+      )
+      testMetricValues(
+        Metric.REQUEST_COUNT,
+        RequestPath.values.map(_.toString)
+      )
+      testMetricValues(
+        Metric.REQUEST_FAILURES,
+        RequestPath.values.map(_.toString)
+      )
+      testMetricValues(
+        Metric.BAD_REQUEST_DATA,
+        RequestPath.values.map(_.toString)
+      )
+      testMetricValues(
+        Metric.DEFINITIONS_SEARCHED,
+        DefinitionSource.values.map(_.toString)
+      )
+      testMetricValues(
+        Metric.DEFINITIONS_NOT_FOUND,
+        DefinitionSource.values.map(_.toString)
+      )
+      testMetricValues(
+        Metric.DEFINITIONS_SEARCHED_IN_CACHE,
+        DefinitionSource.values.map(_.toString)
+      )
+      testMetricValues(
+        Metric.DEFINITIONS_NOT_FOUND_IN_CACHE,
+        DefinitionSource.values.map(_.toString)
+      )
+
+      succeed
+    }
   }
 }

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/metrics/MetricsHolderTest.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/metrics/MetricsHolderTest.scala
@@ -1,0 +1,22 @@
+package com.foreignlanguagereader.domain.metrics
+
+import org.mockito.MockitoSugar
+import org.scalatest.funspec.AsyncFunSpec
+
+class MetricsHolderTest extends AsyncFunSpec with MockitoSugar {
+
+  describe("A metrics holder") {
+    val holder = new MetricHolder()
+
+    it("creates a counter for every metric") {
+      val initializedMetrics =
+        holder.unlabeledCounters.keySet ++ holder.labeledCounters.keySet ++ holder.gauges.keySet ++ holder.timers.keySet
+
+      Metric.values.foreach(metric => {
+        assert(initializedMetrics.contains(metric))
+      })
+      succeed
+    }
+
+  }
+}

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/metrics/MetricsReporterTest.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/metrics/MetricsReporterTest.scala
@@ -1,12 +1,23 @@
 package com.foreignlanguagereader.domain.metrics
 
+import org.mockito.ArgumentMatchers.{any, eq => MockitoEq}
+import org.mockito.MockitoSugar
 import org.scalatest.funspec.AsyncFunSpec
+import play.api.{ConfigLoader, Configuration}
 
-class MetricsReporterTest extends AsyncFunSpec {
+class MetricsReporterTest extends AsyncFunSpec with MockitoSugar {
+  val holder: MetricHolder = mock[MetricHolder]
+  val config: Configuration = mock[Configuration]
 
   describe("A metrics reporter") {
     it("can initialize without error") {
-      val metricsReporter = new MetricsReporter()
+      when(
+        config.getOptional[Boolean](
+          MockitoEq("metrics.reportJVM")
+        )(any[ConfigLoader[Boolean]])
+      ).thenReturn(Some(true))
+
+      val metricsReporter = new MetricsReporter(holder, config)
       succeed
     }
   }

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/service/definition/LanguageDefinitionServiceTest.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/service/definition/LanguageDefinitionServiceTest.scala
@@ -110,9 +110,9 @@ class LanguageDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
         .getDefinitions(Language.ENGLISH, test)
         .map { results =>
           verify(metricsMock)
-            .report(Metric.DEFINITIONS_SEARCHED, "english")
+            .reportDefinitionsSearched(DefinitionSource.WIKTIONARY)
           verify(metricsMock)
-            .report(Metric.DEFINITIONS_SEARCHED_IN_CACHE, "wiktionary")
+            .reportDefinitionsSearchedInCache(DefinitionSource.WIKTIONARY)
           verifyNoMoreInteractions(metricsMock)
           assert(results.length == 1)
           assert(
@@ -138,11 +138,11 @@ class LanguageDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
         .getDefinitions(Language.ENGLISH, test)
         .map { response =>
           verify(metricsMock)
-            .report(Metric.DEFINITIONS_SEARCHED, "english")
+            .reportDefinitionsSearched(DefinitionSource.WIKTIONARY)
           verify(metricsMock)
-            .report(Metric.DEFINITIONS_SEARCHED_IN_CACHE, "wiktionary")
+            .reportDefinitionsSearchedInCache(DefinitionSource.WIKTIONARY)
           verify(metricsMock)
-            .report(Metric.DEFINITIONS_NOT_FOUND, "english")
+            .reportDefinitionsNotFound(DefinitionSource.WIKTIONARY)
           verifyNoMoreInteractions(metricsMock)
           assert(response.isEmpty)
         }


### PR DESCRIPTION
- Metric labels cannot be unbounded without potential to break prometheus
- Enums for all metric labels
- Higher level metrics reporting class that handles the logic
- Lower level metrics reporting class that actually holds counters
- Full RED metrics for downstream dependencies
- Ability to disable JVM metrics