### PR TITLE
Readability changes in document service

### DIFF
--- a/api/app/com/foreignlanguagereader/api/controller/v1/language/DefinitionController.scala
+++ b/api/app/com/foreignlanguagereader/api/controller/v1/language/DefinitionController.scala
@@ -28,10 +28,10 @@ class DefinitionController @Inject() (
 
   def definition(wordLanguage: Language, word: String): Action[AnyContent] =
     Action.async {
-      getDefinitions(wordLanguage, Language.ENGLISH, word)
+      getDefinition(wordLanguage, Language.ENGLISH, word)
     }
 
-  def getDefinitions(
+  def getDefinition(
       wordLanguage: Language,
       definitionLanguage: Language,
       word: String

--- a/api/app/com/foreignlanguagereader/api/controller/v1/language/DefinitionController.scala
+++ b/api/app/com/foreignlanguagereader/api/controller/v1/language/DefinitionController.scala
@@ -1,15 +1,20 @@
 package com.foreignlanguagereader.api.controller.v1.language
 
+import com.foreignlanguagereader.api.error.BadInputException
 import com.foreignlanguagereader.content.types.Language
 import com.foreignlanguagereader.content.types.Language.Language
 import com.foreignlanguagereader.content.types.internal.word.Word
 import com.foreignlanguagereader.domain.metrics.MetricsReporter
+import com.foreignlanguagereader.domain.metrics.label.RequestPath
 import com.foreignlanguagereader.domain.service.definition.DefinitionService
+import com.foreignlanguagereader.dto.v1.definition.DefinitionsRequest
 import play.api.Logger
+import play.api.libs.json.{JsError, JsPath, JsSuccess, JsValue, Reads}
 import play.api.mvc._
 import play.libs.{Json => JavaJson}
 
 import javax.inject._
+import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
@@ -53,4 +58,53 @@ class DefinitionController @Inject() (
         }
       }
   }
+
+  implicit val definitionsRequestReader: Reads[DefinitionsRequest] =
+    (JsPath \ "text")
+      .read[List[String]]
+      .map(words => new DefinitionsRequest(words.asJava))
+
+  def definitions(
+      wordLanguage: Language,
+      definitionLanguage: Language
+  ): Action[JsValue] =
+    Action.async(parse.json) { request =>
+      {
+        metrics.reportLearnerLanguage(wordLanguage, definitionLanguage)
+        request.body.validate[DefinitionsRequest] match {
+          case JsSuccess(definitionsRequest: DefinitionsRequest, _) =>
+            definitionService
+              .getDefinitions(
+                wordLanguage,
+                definitionLanguage,
+                definitionsRequest.getWords.asScala.toList
+                  .map(token => Word.fromToken(token, wordLanguage))
+              )
+              .map(definitions => {
+                Ok(
+                  JavaJson
+                    .stringify(
+                      JavaJson.toJson(definitions.mapValues(_.map(_.toDTO)))
+                    )
+                )
+              })
+          case JsError(errors) =>
+            logger.error(
+              s"Invalid request body given to definitions service: $errors"
+            )
+            metrics.reportBadRequest(RequestPath.DEFINITIONS)
+            Future {
+              BadRequest(
+                JavaJson.stringify(
+                  JavaJson.toJson(
+                    new BadInputException(
+                      "Invalid request body, please try again"
+                    )
+                  )
+                )
+              )
+            }
+        }
+      }
+    }
 }

--- a/api/app/com/foreignlanguagereader/api/controller/v1/language/DefinitionController.scala
+++ b/api/app/com/foreignlanguagereader/api/controller/v1/language/DefinitionController.scala
@@ -60,7 +60,7 @@ class DefinitionController @Inject() (
   }
 
   implicit val definitionsRequestReader: Reads[DefinitionsRequest] =
-    (JsPath \ "text")
+    (JsPath \ "words")
       .read[List[String]]
       .map(words => new DefinitionsRequest(words.asJava))
 

--- a/api/app/com/foreignlanguagereader/api/controller/v1/language/DocumentController.scala
+++ b/api/app/com/foreignlanguagereader/api/controller/v1/language/DocumentController.scala
@@ -27,22 +27,17 @@ class DocumentController @Inject() (
   implicit val documentRequestReader: Reads[DocumentRequest] =
     (JsPath \ "text").read[String].map(text => new DocumentRequest(text))
 
-  def document(wordLanguage: Language): Action[JsValue] =
-    document(wordLanguage, Language.ENGLISH)
-
   def document(
-      wordLanguage: Language,
-      definitionLanguage: Language
+      wordLanguage: Language
   ): Action[JsValue] =
     Action.async(parse.json) { request =>
       {
-        metrics.reportLearnerLanguage(wordLanguage, definitionLanguage)
+        metrics.reportLearnerLanguage(wordLanguage, Language.UNKNOWN)
         request.body.validate[DocumentRequest] match {
           case JsSuccess(documentRequest: DocumentRequest, _) =>
             documentService
               .getWordsForDocument(
                 wordLanguage,
-                definitionLanguage,
                 documentRequest.getText
               )
               .map(words => {

--- a/api/app/com/foreignlanguagereader/api/metrics/ApiMetricReporter.scala
+++ b/api/app/com/foreignlanguagereader/api/metrics/ApiMetricReporter.scala
@@ -8,12 +8,15 @@ import scala.util.matching.Regex
 
 object ApiMetricReporter {
   val languageRegex: String = s"[${Language.values.mkString("|")}]+"
-  val definitionsRegex: Regex =
+  val definitionRegex: Regex =
     s"/v1/language/definition/$languageRegex/[^/]+/?".r
+  val definitionsRegex: Regex =
+    s"/v1/language/definitions/$languageRegex/$languageRegex/?".r
   val documentRegex: Regex = s"/v1/language/document/$languageRegex/?".r
 
   def getLabelFromPath(path: String): RequestPath =
     path match {
+      case definitionRegex()      => RequestPath.DEFINITION
       case definitionsRegex()     => RequestPath.DEFINITIONS
       case documentRegex()        => RequestPath.DOCUMENT
       case "/health"              => RequestPath.HEALTH

--- a/api/conf/routes
+++ b/api/conf/routes
@@ -7,5 +7,6 @@ GET    /readiness    com.foreignlanguagereader.api.controller.v1.HealthControlle
 GET    /auth    com.foreignlanguagereader.api.controller.v1.HealthController.checkAuthentication
 
 GET    /v1/language/definition/:wordlanguage/:word/ com.foreignlanguagereader.api.controller.v1.language.DefinitionController.definition(wordlanguage: com.foreignlanguagereader.content.types.Language.Language, word: String)
+POST    /v1/language/definition/:wordlanguage/:definitionLanguage/ com.foreignlanguagereader.api.controller.v1.language.DefinitionController.definitions(wordlanguage: com.foreignlanguagereader.content.types.Language.Language, definitionLanguage: com.foreignlanguagereader.content.types.Language.Language)
 POST   /v1/language/document/:wordlanguage/ com.foreignlanguagereader.api.controller.v1.language.DocumentController.document(wordlanguage: com.foreignlanguagereader.content.types.Language.Language)
 GET    /v1/vocabulary/words com.foreignlanguagereader.api.controller.v1.vocabulary.VocabularyController.getAllWords

--- a/api/conf/routes
+++ b/api/conf/routes
@@ -7,6 +7,6 @@ GET    /readiness    com.foreignlanguagereader.api.controller.v1.HealthControlle
 GET    /auth    com.foreignlanguagereader.api.controller.v1.HealthController.checkAuthentication
 
 GET    /v1/language/definition/:wordlanguage/:word/ com.foreignlanguagereader.api.controller.v1.language.DefinitionController.definition(wordlanguage: com.foreignlanguagereader.content.types.Language.Language, word: String)
-POST    /v1/language/definition/:wordlanguage/:definitionLanguage/ com.foreignlanguagereader.api.controller.v1.language.DefinitionController.definitions(wordlanguage: com.foreignlanguagereader.content.types.Language.Language, definitionLanguage: com.foreignlanguagereader.content.types.Language.Language)
+POST   /v1/language/definitions/:wordlanguage/:definitionLanguage/ com.foreignlanguagereader.api.controller.v1.language.DefinitionController.definitions(wordlanguage: com.foreignlanguagereader.content.types.Language.Language, definitionLanguage: com.foreignlanguagereader.content.types.Language.Language)
 POST   /v1/language/document/:wordlanguage/ com.foreignlanguagereader.api.controller.v1.language.DocumentController.document(wordlanguage: com.foreignlanguagereader.content.types.Language.Language)
 GET    /v1/vocabulary/words com.foreignlanguagereader.api.controller.v1.vocabulary.VocabularyController.getAllWords

--- a/api/test/com/foreignlanguagereader/api/controller/v1/language/DefinitionControllerSpec.scala
+++ b/api/test/com/foreignlanguagereader/api/controller/v1/language/DefinitionControllerSpec.scala
@@ -6,15 +6,19 @@ import com.foreignlanguagereader.content.types.internal.word.Word
 import com.foreignlanguagereader.domain.metrics.MetricsReporter
 import com.foreignlanguagereader.domain.metrics.label.RequestPath
 import com.foreignlanguagereader.domain.service.definition.DefinitionService
+import com.foreignlanguagereader.dto.v1.definition.DefinitionsRequest
 import io.prometheus.client.Histogram
 import org.mockito.{Mockito, MockitoSugar}
 import org.scalatest.Outcome
 import play.api.Application
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.Json
 import play.api.test.Helpers._
 import play.api.test._
+import play.libs.{Json => JavaJson}
 
+import scala.collection.JavaConverters._
 import scala.concurrent.Future
 
 class DefinitionControllerSpec extends PlaySpec with MockitoSugar {
@@ -32,7 +36,7 @@ class DefinitionControllerSpec extends PlaySpec with MockitoSugar {
     super.withFixture(test)
   }
 
-  "Definitions endpoints" should {
+  "Definition endpoint" should {
     val goodRequest = "/v1/language/definition/SPANISH/test/"
     val badLanguageRequest = "/v1/language/definition/ELEPHANT/test/"
 
@@ -78,6 +82,46 @@ class DefinitionControllerSpec extends PlaySpec with MockitoSugar {
 
       status(badResponse) mustBe 400
       contentAsString(badResponse) must include("{\"message\":\"ELEPHANT\"}")
+    }
+  }
+
+  "Definitions endpoint" should {
+    val goodRequest = "/v1/language/definitions/ENGLISH/SPANISH/"
+
+    "get good requests from the router" in {
+      when(
+        mockDefinitionService
+          .getDefinitions(
+            Language.ENGLISH,
+            Language.SPANISH,
+            List(
+              Word.fromToken("test", Language.ENGLISH),
+              Word.fromToken("query", Language.ENGLISH)
+            )
+          )
+      ).thenReturn(Future.successful(Map()))
+
+      val mockTimer = Some(mock[Histogram.Timer])
+      when(
+        mockMetricsReporter.reportRequestStarted(
+          "POST",
+          RequestPath.DEFINITIONS
+        )
+      ).thenReturn(mockTimer)
+
+      val definitionRequest =
+        JavaJson.stringify(
+          JavaJson.toJson(new DefinitionsRequest(List("test", "query").asJava))
+        )
+      val request =
+        FakeRequest(POST, goodRequest).withJsonBody(
+          Json.parse(definitionRequest)
+        )
+
+      val goodResponse = route(app, request).get
+
+      status(goodResponse) mustBe OK
+      contentAsString(goodResponse) must include("{}")
     }
   }
 }

--- a/api/test/com/foreignlanguagereader/api/controller/v1/language/DocumentControllerSpec.scala
+++ b/api/test/com/foreignlanguagereader/api/controller/v1/language/DocumentControllerSpec.scala
@@ -45,7 +45,6 @@ class DocumentControllerSpec extends PlaySpec with MockitoSugar {
         mockDocumentService
           .getWordsForDocument(
             Language.ENGLISH,
-            Language.ENGLISH,
             document
           )
       ).thenReturn(Future.successful(List()))

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/Language.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/Language.scala
@@ -10,6 +10,7 @@ object Language extends Enumeration {
   val CHINESE_TRADITIONAL: Language.Value = Value("CHINESE_TRADITIONAL")
   val ENGLISH: Value = Value("ENGLISH")
   val SPANISH: Value = Value("SPANISH")
+  val UNKNOWN: Value = Value("UNKNOWN")
 
   def fromString(s: String): Option[Language] =
     Language.values.find(_.toString === s)

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/metrics/label/RequestPath.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/metrics/label/RequestPath.scala
@@ -3,6 +3,7 @@ package com.foreignlanguagereader.domain.metrics.label
 object RequestPath extends Enumeration {
   type RequestPath = Value
 
+  val DEFINITION: Value = Value("definitio")
   val DEFINITIONS: Value = Value("definition")
   val DOCUMENT: Value = Value("document")
   val HEALTH: Value = Value("health")

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/service/DocumentService.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/service/DocumentService.scala
@@ -1,6 +1,5 @@
 package com.foreignlanguagereader.domain.service
 
-import cats.implicits._
 import com.foreignlanguagereader.content.types.Language.Language
 import com.foreignlanguagereader.content.types.internal.word.Word
 import com.foreignlanguagereader.domain.client.circuitbreaker.{
@@ -32,7 +31,6 @@ class DocumentService @Inject() (
    */
   def getWordsForDocument(
       wordLanguage: Language,
-      definitionLanguage: Language,
       document: String
   ): Future[List[Word]] =
     getWordsFromLanguageService(wordLanguage, document)

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/service/DocumentService.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/service/DocumentService.scala
@@ -9,7 +9,6 @@ import com.foreignlanguagereader.domain.client.circuitbreaker.{
 }
 import com.foreignlanguagereader.domain.client.google.GoogleCloudClient
 import com.foreignlanguagereader.domain.client.languageservice.LanguageServiceClient
-import com.foreignlanguagereader.domain.service.definition.DefinitionService
 import com.google.inject.Inject
 
 import javax.inject
@@ -21,7 +20,6 @@ import scala.concurrent.{ExecutionContext, Future}
 class DocumentService @Inject() (
     val googleCloudClient: GoogleCloudClient,
     languageServiceClient: LanguageServiceClient,
-    val definitionService: DefinitionService,
     implicit val ec: ExecutionContext
 ) {
   val logger: Logger = Logger(this.getClass)

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/service/DocumentService.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/service/DocumentService.scala
@@ -35,19 +35,7 @@ class DocumentService @Inject() (
       definitionLanguage: Language,
       document: String
   ): Future[List[Word]] =
-    tokenizeDocument(wordLanguage, document).flatMap(words => {
-      words.toList
-        .traverse(word =>
-          definitionService
-            .getDefinition(wordLanguage, definitionLanguage, word)
-            .map(d => word.copy(definitions = d))
-        )
-    })
-
-  def tokenizeDocument(
-      language: Language,
-      document: String
-  ): Future[Set[Word]] = getWordsFromLanguageService(language, document)
+    getWordsFromLanguageService(wordLanguage, document)
 
   def getWordsFromGoogleCloud(
       language: Language,

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/service/DocumentService.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/service/DocumentService.scala
@@ -65,12 +65,12 @@ class DocumentService @Inject() (
   def getWordsFromLanguageService(
       language: Language,
       document: String
-  ): Future[Set[Word]] = {
+  ): Future[List[Word]] = {
     languageServiceClient
       .getWordsForDocument(language, document)
       .map {
-        case CircuitBreakerAttempt(result)  => result.toSet
-        case CircuitBreakerNonAttempt()     => Set[Word]()
+        case CircuitBreakerAttempt(result)  => result
+        case CircuitBreakerNonAttempt()     => List[Word]()
         case CircuitBreakerFailedAttempt(e) => throw e
       }
   }

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/service/definition/DefinitionService.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/service/definition/DefinitionService.scala
@@ -44,11 +44,11 @@ class DefinitionService @Inject() (
       wordLanguage: Language,
       definitionLanguage: Language,
       words: List[Word]
-  ): Future[Map[Word, List[Definition]]] = {
+  ): Future[Map[String, List[Definition]]] = {
     Future
       .traverse(words)(word =>
         getDefinition(wordLanguage, definitionLanguage, word)
       )
-      .map(definitions => words.zip(definitions).toMap)
+      .map(definitions => words.map(_.token).zip(definitions).toMap)
   }
 }

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/service/definition/DefinitionService.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/service/definition/DefinitionService.scala
@@ -39,4 +39,16 @@ class DefinitionService @Inject() (
       case Language.SPANISH =>
         spanishDefinitionService.getDefinitions(definitionLanguage, word)
     }
+
+  def getDefinitions(
+      wordLanguage: Language,
+      definitionLanguage: Language,
+      words: List[Word]
+  ): Future[Map[Word, List[Definition]]] = {
+    Future
+      .traverse(words)(word =>
+        getDefinition(wordLanguage, definitionLanguage, word)
+      )
+      .map(definitions => words.zip(definitions).toMap)
+  }
 }

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/service/DocumentServiceTest.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/service/DocumentServiceTest.scala
@@ -48,7 +48,7 @@ class DocumentServiceTest extends AsyncFunSpec with MockitoSugar {
       ).thenReturn(Future.successful(CircuitBreakerAttempt(List())))
 
       documentService
-        .getWordsForDocument(Language.CHINESE, Language.CHINESE, "some words")
+        .getWordsForDocument(Language.CHINESE, "some words")
         .map(result => assert(result.isEmpty))
     }
 
@@ -59,7 +59,7 @@ class DocumentServiceTest extends AsyncFunSpec with MockitoSugar {
       ).thenReturn(Future.successful(CircuitBreakerNonAttempt()))
 
       documentService
-        .getWordsForDocument(Language.CHINESE, Language.CHINESE, "some words")
+        .getWordsForDocument(Language.CHINESE, "some words")
         .map(result => assert(result.isEmpty))
     }
 
@@ -74,7 +74,6 @@ class DocumentServiceTest extends AsyncFunSpec with MockitoSugar {
       )
       documentService
         .getWordsForDocument(
-          Language.CHINESE_TRADITIONAL,
           Language.CHINESE_TRADITIONAL,
           "some words"
         )
@@ -149,7 +148,7 @@ class DocumentServiceTest extends AsyncFunSpec with MockitoSugar {
       ).thenReturn(Future.successful(List(phraseDefinition)))
 
       documentService
-        .getWordsForDocument(Language.ENGLISH, Language.SPANISH, "test phrase")
+        .getWordsForDocument(Language.ENGLISH, "test phrase")
         .map(result => {
           assert(result.size == 2)
           val test = result.head

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/service/DocumentServiceTest.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/service/DocumentServiceTest.scala
@@ -1,10 +1,6 @@
 package com.foreignlanguagereader.domain.service
 
 import com.foreignlanguagereader.content.types.Language
-import com.foreignlanguagereader.content.types.internal.definition.{
-  DefinitionSource,
-  EnglishDefinition
-}
 import com.foreignlanguagereader.content.types.internal.word
 import com.foreignlanguagereader.content.types.internal.word.{
   PartOfSpeech,

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/service/DocumentServiceTest.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/service/DocumentServiceTest.scala
@@ -17,7 +17,6 @@ import com.foreignlanguagereader.domain.client.circuitbreaker.{
 }
 import com.foreignlanguagereader.domain.client.google.GoogleCloudClient
 import com.foreignlanguagereader.domain.client.languageservice.LanguageServiceClient
-import com.foreignlanguagereader.domain.service.definition.DefinitionService
 import org.mockito.MockitoSugar
 import org.scalatest.funspec.AsyncFunSpec
 
@@ -28,15 +27,12 @@ class DocumentServiceTest extends AsyncFunSpec with MockitoSugar {
     mock[GoogleCloudClient]
   val mockLanguageService: LanguageServiceClient =
     mock[LanguageServiceClient]
-  val mockDefinitionService: DefinitionService =
-    mock[DefinitionService]
   val ec: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
 
   val documentService =
     new DocumentService(
       mockGoogleCloudClient,
       mockLanguageService,
-      mockDefinitionService,
       ec
     )
 
@@ -117,36 +113,6 @@ class DocumentServiceTest extends AsyncFunSpec with MockitoSugar {
         Future.apply(CircuitBreakerAttempt(List(testWord, phraseWord)))
       )
 
-      val testDefinition = EnglishDefinition(
-        subdefinitions = List("test"),
-        ipa = "",
-        tag = PartOfSpeech.NOUN,
-        examples = None,
-        wordLanguage = Language.ENGLISH,
-        definitionLanguage = Language.SPANISH,
-        source = DefinitionSource.MULTIPLE,
-        token = "test"
-      )
-      when(
-        mockDefinitionService
-          .getDefinition(Language.ENGLISH, Language.SPANISH, testWord)
-      ).thenReturn(Future.successful(List(testDefinition)))
-
-      val phraseDefinition = EnglishDefinition(
-        subdefinitions = List("phrase"),
-        ipa = "",
-        tag = PartOfSpeech.VERB,
-        examples = None,
-        wordLanguage = Language.ENGLISH,
-        definitionLanguage = Language.SPANISH,
-        source = DefinitionSource.MULTIPLE,
-        token = "phrase"
-      )
-      when(
-        mockDefinitionService
-          .getDefinition(Language.ENGLISH, Language.SPANISH, phraseWord)
-      ).thenReturn(Future.successful(List(phraseDefinition)))
-
       documentService
         .getWordsForDocument(Language.ENGLISH, "test phrase")
         .map(result => {
@@ -154,11 +120,8 @@ class DocumentServiceTest extends AsyncFunSpec with MockitoSugar {
           val test = result.head
           val phrase = result(1)
 
-          assert(test == testWord.copy(definitions = List(testDefinition)))
-          assert(
-            phrase == phraseWord
-              .copy(definitions = List(phraseDefinition))
-          )
+          assert(test == testWord)
+          assert(phrase == phraseWord)
         })
     }
   }

--- a/dto/src/main/java/com/foreignlanguagereader/dto/v1/definition/DefinitionsRequest.java
+++ b/dto/src/main/java/com/foreignlanguagereader/dto/v1/definition/DefinitionsRequest.java
@@ -1,0 +1,15 @@
+package com.foreignlanguagereader.dto.v1.definition;
+
+import java.util.List;
+
+public class DefinitionsRequest {
+    private final List<String> words;
+
+    public DefinitionsRequest(List<String> words) {
+        this.words = words;
+    }
+
+    public List<String> getWords() {
+        return words;
+    }
+}


### PR DESCRIPTION
- Words are returned in the query order.
- Definitions are not looked up when parsing a document.
- Definitions can be looked up in bulk.