### PR TITLE
HSK difficulty level

### DIFF
--- a/content/src/main/scala/com/foreignlanguagereader/content/difficulty/CEFRDifficultyLevel.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/difficulty/CEFRDifficultyLevel.scala
@@ -1,0 +1,21 @@
+package com.foreignlanguagereader.content.difficulty
+
+import cats.implicits._
+import play.api.libs.json.{Reads, Writes}
+
+object CEFRDifficultyLevel extends Enumeration {
+  type CEFRDifficultyLevel = Value
+  val A1_BEGINNING: Value = Value("A1")
+  val A2_ELEMENTARY: Value = Value("A2")
+  val B1_INTERMEDIATE: Value = Value("B1")
+  val B2_UPPER_INTERMEDIATE: Value = Value("B2")
+  val C1_ADVANCED: Value = Value("C1")
+  val C2_PROFICIENCY: Value = Value("C2")
+
+  def fromString(s: String): Option[CEFRDifficultyLevel] =
+    CEFRDifficultyLevel.values.find(_.toString === s)
+
+  implicit val reads: Reads[CEFRDifficultyLevel] =
+    Reads.enumNameReads(CEFRDifficultyLevel)
+  implicit val writes: Writes[CEFRDifficultyLevel] = Writes.enumNameWrites
+}

--- a/content/src/main/scala/com/foreignlanguagereader/content/difficulty/DifficultyFinder.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/difficulty/DifficultyFinder.scala
@@ -1,0 +1,11 @@
+package com.foreignlanguagereader.content.difficulty
+
+import com.foreignlanguagereader.content.difficulty.CEFRDifficultyLevel.CEFRDifficultyLevel
+
+trait DifficultyFinder[T] {
+  def getDifficulty(token: String): T
+  def convertDifficultyToCEFR(level: T): CEFRDifficultyLevel
+
+  def getDifficultyAsCEFR(token: String): CEFRDifficultyLevel =
+    convertDifficultyToCEFR(getDifficulty(token))
+}

--- a/content/src/main/scala/com/foreignlanguagereader/content/difficulty/chinese/hsk/HSKDifficultyFinder.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/difficulty/chinese/hsk/HSKDifficultyFinder.scala
@@ -1,0 +1,26 @@
+package com.foreignlanguagereader.content.difficulty.chinese.hsk
+
+import com.foreignlanguagereader.content.difficulty.CEFRDifficultyLevel.CEFRDifficultyLevel
+import com.foreignlanguagereader.content.difficulty.{
+  CEFRDifficultyLevel,
+  DifficultyFinder
+}
+import com.foreignlanguagereader.content.util.ContentFileLoader
+import com.foreignlanguagereader.dto.v1.definition.chinese.HSKLevel
+
+object HSKDifficultyFinder extends DifficultyFinder[HSKLevel] {
+  private[this] val hsk: HskHolder = ContentFileLoader
+    .loadJsonResourceFile[HskHolder]("/chinese/hsk.json")
+
+  override def getDifficulty(token: String): HSKLevel = hsk.getLevel(token)
+  override def convertDifficultyToCEFR(level: HSKLevel): CEFRDifficultyLevel =
+    level match {
+      case HSKLevel.ONE   => CEFRDifficultyLevel.A1_BEGINNING
+      case HSKLevel.TWO   => CEFRDifficultyLevel.A2_ELEMENTARY
+      case HSKLevel.THREE => CEFRDifficultyLevel.B1_INTERMEDIATE
+      case HSKLevel.FOUR  => CEFRDifficultyLevel.B2_UPPER_INTERMEDIATE
+      case HSKLevel.FIVE  => CEFRDifficultyLevel.C1_ADVANCED
+      case HSKLevel.SIX   => CEFRDifficultyLevel.C2_PROFICIENCY
+      case HSKLevel.NONE  => CEFRDifficultyLevel.C2_PROFICIENCY
+    }
+}

--- a/content/src/main/scala/com/foreignlanguagereader/content/difficulty/chinese/hsk/HskHolder.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/difficulty/chinese/hsk/HskHolder.scala
@@ -1,19 +1,7 @@
-package com.foreignlanguagereader.content.enrichers.chinese
+package com.foreignlanguagereader.content.difficulty.chinese.hsk
 
-import com.foreignlanguagereader.content.util.ContentFileLoader
 import com.foreignlanguagereader.dto.v1.definition.chinese.HSKLevel
-import com.github.houbb.opencc4j.util.ZhConverterUtil
 import play.api.libs.json.{Json, Reads}
-
-object HSKLevelFinder {
-  private[this] val hsk: HskHolder = ContentFileLoader
-    .loadJsonResourceFile[HskHolder]("/chinese/hsk.json")
-
-  def sentenceIsTraditional(sentence: String): Boolean =
-    ZhConverterUtil.isTraditional(sentence)
-
-  def getHSK(simplified: String): HSKLevel = hsk.getLevel(simplified)
-}
 
 case class HskHolder(
     hsk1: Set[String],

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/internal/definition/ChineseDefinition.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/internal/definition/ChineseDefinition.scala
@@ -1,8 +1,8 @@
 package com.foreignlanguagereader.content.types.internal.definition
 
+import com.foreignlanguagereader.content.difficulty.chinese.hsk.HSKDifficultyFinder
 import com.foreignlanguagereader.content.enrichers.chinese.{
   ChinesePronunciationGenerator,
-  HSKLevelFinder,
   SimplifiedTraditionalConverter
 }
 import com.foreignlanguagereader.content.types.Language
@@ -59,7 +59,7 @@ case class ChineseDefinition(
     }
 
   val hsk: HSKLevel = simplified match {
-    case Some(s) => HSKLevelFinder.getHSK(s)
+    case Some(s) => HSKDifficultyFinder.getDifficulty(s)
     case None    => HSKLevel.NONE
   }
 

--- a/content/src/test/scala/com/foreignlanguagereader/content/util/ContentFileLoaderTest.scala
+++ b/content/src/test/scala/com/foreignlanguagereader/content/util/ContentFileLoaderTest.scala
@@ -1,10 +1,8 @@
 package com.foreignlanguagereader.content.util
 
 import com.fasterxml.jackson.databind.exc.MismatchedInputException
-import com.foreignlanguagereader.content.enrichers.chinese.{
-  ChinesePronunciationFromFile,
-  HskHolder
-}
+import com.foreignlanguagereader.content.difficulty.chinese.hsk.HskHolder
+import com.foreignlanguagereader.content.enrichers.chinese.ChinesePronunciationFromFile
 import org.scalatest.funspec.AnyFunSpec
 
 class ContentFileLoaderTest extends AnyFunSpec {


### PR DESCRIPTION
Generalized interface for getting difficulties. Chose CEFR for setting difficulties in a way that can be shared across all languages.