### PR TITLE
Process tokens into lowercase

### DIFF
--- a/content/src/main/scala/com/foreignlanguagereader/content/types/internal/word/Word.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/internal/word/Word.scala
@@ -42,6 +42,8 @@ object Word {
       number = None,
       proper = None,
       tense = None,
-      processedToken = token
+      processedToken = Word.processToken(token)
     )
+
+  def processToken(token: String): String = token.toLowerCase
 }

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/internal/word/Word.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/internal/word/Word.scala
@@ -21,10 +21,14 @@ case class Word(
     tense: Option[WordTense],
     processedToken: String
 ) {
-  lazy val toDTO: WordDTO = {
-    val defs = definitions.map(_.toDTO)
-    new WordDTO(token, tag.toString, lemma, defs.asJava)
-  }
+  lazy val toDTO: WordDTO =
+    new WordDTO(
+      token,
+      processedToken,
+      tag.toString,
+      lemma,
+      definitions.map(_.toDTO).asJava
+    )
 }
 object Word {
   def fromToken(token: String, language: Language): Word =

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/client/google/GoogleCloudClient.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/client/google/GoogleCloudClient.scala
@@ -111,7 +111,7 @@ class GoogleCloudClient @Inject() (
           number = googleCountToDomainCount(token.getPartOfSpeech.getNumber),
           proper = isProperNoun(token.getPartOfSpeech.getProper),
           tense = googleTenseToDomainTense(token.getPartOfSpeech.getTense),
-          processedToken = token.getText.getContent
+          processedToken = Word.processToken(token.getText.getContent)
         )
       )
 

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/client/languageservice/LanguageServiceClient.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/client/languageservice/LanguageServiceClient.scala
@@ -79,7 +79,7 @@ class LanguageServiceClient @Inject() (
             number = None,
             tense = None,
             proper = None,
-            processedToken = word.token
+            processedToken = Word.processToken(word.token)
           )
         )
       )

--- a/dto/src/main/java/com/foreignlanguagereader/dto/v1/word/WordDTO.java
+++ b/dto/src/main/java/com/foreignlanguagereader/dto/v1/word/WordDTO.java
@@ -5,13 +5,15 @@ import com.foreignlanguagereader.dto.v1.definition.DefinitionDTO;
 import java.util.List;
 
 public class WordDTO {
-    private String token;
-    private String tag;
-    private String lemma;
-    private List<DefinitionDTO> definitions;
+    private final String token;
+    private final String processedToken;
+    private final String tag;
+    private final String lemma;
+    private final List<DefinitionDTO> definitions;
 
-    public WordDTO(String token, String tag, String lemma, List<DefinitionDTO> definitions) {
+    public WordDTO(String token, String processedToken, String tag, String lemma, List<DefinitionDTO> definitions) {
         this.token = token;
+        this.processedToken = processedToken;
         this.tag = tag;
         this.lemma = lemma;
         this.definitions = definitions;
@@ -31,5 +33,9 @@ public class WordDTO {
 
     public String getToken() {
         return token;
+    }
+
+    public String getProcessedToken() {
+        return processedToken;
     }
 }


### PR DESCRIPTION
We don't have definition results in uppercase, but users may type them in. Let's smarten this up by providing a definition service lookup key.