### PR TITLE
Definitions show source

### DIFF
--- a/content/src/main/scala/com/foreignlanguagereader/content/types/internal/definition/ChineseDefinition.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/internal/definition/ChineseDefinition.scala
@@ -10,7 +10,10 @@ import com.foreignlanguagereader.content.types.Language.Language
 import com.foreignlanguagereader.content.types.internal.definition.DefinitionSource.DefinitionSource
 import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech
 import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech.PartOfSpeech
-import com.foreignlanguagereader.dto.v1.definition.ChineseDefinitionDTO
+import com.foreignlanguagereader.dto.v1.definition.{
+  ChineseDefinitionDTO,
+  DefinitionSourceDTO
+}
 import com.foreignlanguagereader.dto.v1.definition.chinese.{
   ChinesePronunciation,
   HSKLevel
@@ -68,6 +71,7 @@ case class ChineseDefinition(
       id,
       subdefinitions.asJava,
       PartOfSpeech.toDTO(tag),
+      DefinitionSource.toDTO(source),
       examples.getOrElse(List()).asJava,
       simplified.asJava,
       traditional.map(_.asJava).asJava,

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/internal/definition/DefinitionSource.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/internal/definition/DefinitionSource.scala
@@ -1,6 +1,7 @@
 package com.foreignlanguagereader.content.types.internal.definition
 
 import cats.implicits._
+import com.foreignlanguagereader.dto.v1.definition.DefinitionSourceDTO
 import play.api.libs.json._
 
 /*
@@ -29,5 +30,17 @@ object DefinitionSource extends Enumeration {
         }
       def writes(source: DefinitionSource.DefinitionSource): JsString =
         JsString(source.toString)
+    }
+
+  def toDTO(source: DefinitionSource): DefinitionSourceDTO =
+    source match {
+      case CEDICT => DefinitionSourceDTO.CEDICT
+      case MIRRIAM_WEBSTER_LEARNERS =>
+        DefinitionSourceDTO.MIRRIAM_WEBSTER_LEARNERS
+      case MIRRIAM_WEBSTER_SPANISH =>
+        DefinitionSourceDTO.MIRRIAM_WEBSTER_SPANISH
+      case WIKTIONARY_SIMPLE_ENGLISH =>
+        DefinitionSourceDTO.WIKTIONARY_SIMPLE_ENGLISH
+      case _ => DefinitionSourceDTO.MULTIPLE
     }
 }

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/internal/definition/EnglishDefinition.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/internal/definition/EnglishDefinition.scala
@@ -27,6 +27,7 @@ case class EnglishDefinition(
       id,
       subdefinitions.asJava,
       PartOfSpeech.toDTO(tag),
+      DefinitionSource.toDTO(source),
       examples.getOrElse(List()).asJava
     )
 }

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/internal/definition/SpanishDefinition.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/internal/definition/SpanishDefinition.scala
@@ -27,6 +27,7 @@ case class SpanishDefinition(
       id,
       subdefinitions.asJava,
       PartOfSpeech.toDTO(tag),
+      DefinitionSource.toDTO(source),
       examples.getOrElse(List()).asJava
     )
 }

--- a/dto/src/main/java/com/foreignlanguagereader/dto/v1/definition/ChineseDefinitionDTO.java
+++ b/dto/src/main/java/com/foreignlanguagereader/dto/v1/definition/ChineseDefinitionDTO.java
@@ -12,9 +12,9 @@ public class ChineseDefinitionDTO extends DefinitionDTO {
     private String pronunciation;
     private HSKLevel hsk;
 
-    public ChineseDefinitionDTO(String id, List<String> subdefinitions, PartOfSpeechDTO tag, List<String> examples,
+    public ChineseDefinitionDTO(String id, List<String> subdefinitions, PartOfSpeechDTO tag, DefinitionSourceDTO source, List<String> examples,
                                 Optional<String> simplified, Optional<List<String>> traditional, String pronunciation, HSKLevel hsk) {
-        super(id, subdefinitions, tag, examples);
+        super(id, subdefinitions, tag, source, examples);
         this.simplified = simplified;
         this.traditional = traditional;
         this.pronunciation = pronunciation;

--- a/dto/src/main/java/com/foreignlanguagereader/dto/v1/definition/DefinitionDTO.java
+++ b/dto/src/main/java/com/foreignlanguagereader/dto/v1/definition/DefinitionDTO.java
@@ -8,13 +8,15 @@ public class DefinitionDTO {
     private final String id;
     private final List<String> subdefinitions;
     private final PartOfSpeechDTO tag;
+    private final DefinitionSourceDTO source;
     private final List<String> examples;
 
-    public DefinitionDTO(String id, List<String> subdefinitions, PartOfSpeechDTO tag, List<String> examples) {
+    public DefinitionDTO(String id, List<String> subdefinitions, PartOfSpeechDTO tag, DefinitionSourceDTO source, List<String> examples) {
         this.id = id;
         this.subdefinitions = subdefinitions;
         this.tag = tag;
         this.examples = examples;
+        this.source = source;
     }
 
     public String getId() {
@@ -27,6 +29,10 @@ public class DefinitionDTO {
 
     public PartOfSpeechDTO getTag() {
         return tag;
+    }
+
+    public DefinitionSourceDTO getSource() {
+        return source;
     }
 
     public List<String> getExamples() {

--- a/dto/src/main/java/com/foreignlanguagereader/dto/v1/definition/DefinitionSourceDTO.java
+++ b/dto/src/main/java/com/foreignlanguagereader/dto/v1/definition/DefinitionSourceDTO.java
@@ -1,0 +1,9 @@
+package com.foreignlanguagereader.dto.v1.definition;
+
+public enum DefinitionSourceDTO {
+    CEDICT,
+    MIRRIAM_WEBSTER_LEARNERS,
+    MIRRIAM_WEBSTER_SPANISH,
+    WIKTIONARY_SIMPLE_ENGLISH,
+    MULTIPLE
+}


### PR DESCRIPTION
For compliance reasons, we should know where our content came from. Let's surface this to the frontend so that we can appropriately attribute definitions.