### PR TITLE
Get templates in simple english wiktionary

### DIFF
--- a/jobs/src/main/scala/com/foreignlanguagereader/jobs/definitions/TemplateExtractor.scala
+++ b/jobs/src/main/scala/com/foreignlanguagereader/jobs/definitions/TemplateExtractor.scala
@@ -1,0 +1,18 @@
+package com.foreignlanguagereader.jobs.definitions
+
+object TemplateExtractor {
+  val leftBrace = "\\{"
+  val rightBrace = "\\}"
+  val pipe = "\\|"
+  val notPipeCaptureGroup = "([^|\\{]+)"
+  val notRightBraceCaptureGroup = "([^\\}]*)"
+
+  val templateRegex: String =
+    leftBrace + leftBrace + notPipeCaptureGroup + pipe + notRightBraceCaptureGroup + rightBrace + rightBrace
+  val extractTemplatesFromString: String => Array[Array[String]] =
+    (input: String) =>
+      templateRegex.r
+        .findAllIn(input)
+        .matchData
+        .map(m => Array(m.group(1), m.group(2)))
+        .toArray

--- a/jobs/src/main/scala/com/foreignlanguagereader/jobs/definitions/TemplateExtractor.scala
+++ b/jobs/src/main/scala/com/foreignlanguagereader/jobs/definitions/TemplateExtractor.scala
@@ -9,6 +9,18 @@ object TemplateExtractor {
 
   val templateRegex: String =
     leftBrace + leftBrace + notPipeCaptureGroup + pipe + notRightBraceCaptureGroup + rightBrace + rightBrace
+  def loadWiktionaryDump(
+      path: String
+  )(implicit spark: SparkSession): Dataset[WiktionaryGenericText] = {
+    import spark.implicits._
+
+    spark.read
+      .option("rowTag", "page")
+      .xml(path)
+      .select("revision.text._VALUE")
+      .withColumnRenamed("_VALUE", "text")
+      .as[WiktionaryGenericText]
+  }
   val extractTemplatesFromString: String => Array[Array[String]] =
     (input: String) =>
       templateRegex.r
@@ -16,3 +28,4 @@ object TemplateExtractor {
         .matchData
         .map(m => Array(m.group(1), m.group(2)))
         .toArray
+case class WiktionaryGenericText(text: String)

--- a/jobs/src/main/scala/com/foreignlanguagereader/jobs/definitions/TemplateExtractor.scala
+++ b/jobs/src/main/scala/com/foreignlanguagereader/jobs/definitions/TemplateExtractor.scala
@@ -14,6 +14,28 @@ object TemplateExtractor {
 
   val templateRegex: String =
     leftBrace + leftBrace + notPipeCaptureGroup + pipe + notRightBraceCaptureGroup + rightBrace + rightBrace
+
+  val backupsBasePath =
+    "s3a://foreign-language-reader-content/definitions/wiktionary/"
+
+  val backups = Map(
+    "simple" -> "simplewiktionary-20200301-pages-meta-current.xml"
+  )
+
+  def main(args: Array[String]): Unit = {
+    implicit val spark: SparkSession = SparkSession.builder
+      .appName(s"Wiktionary Template Extractor")
+      .getOrCreate()
+
+    backups.foreach {
+      case (dictionary, path) =>
+        extractTemplatesFromBackup(
+          s"$backupsBasePath/$path",
+          s"$backupsBasePath/templates/$dictionary"
+        )
+    }
+  }
+
   def extractTemplatesFromBackup(path: String, resultPath: String)(implicit
       spark: SparkSession
   ): Unit = {

--- a/jobs/src/main/scala/com/foreignlanguagereader/jobs/definitions/TemplateExtractor.scala
+++ b/jobs/src/main/scala/com/foreignlanguagereader/jobs/definitions/TemplateExtractor.scala
@@ -14,6 +14,17 @@ object TemplateExtractor {
 
   val templateRegex: String =
     leftBrace + leftBrace + notPipeCaptureGroup + pipe + notRightBraceCaptureGroup + rightBrace + rightBrace
+  def extractTemplatesFromBackup(path: String, resultPath: String)(implicit
+      spark: SparkSession
+  ): Unit = {
+    val templateInstances =
+      extractTemplateInstances(loadWiktionaryDump(path)).cache()
+    templateInstances.write.csv(s"$resultPath/instances.csv")
+
+    val templates = extractTemplateCount(templateInstances)
+    templates.write.csv(s"$resultPath/templates.csv")
+  }
+
   def loadWiktionaryDump(
       path: String
   )(implicit spark: SparkSession): Dataset[WiktionaryGenericText] = {
@@ -67,3 +78,4 @@ object TemplateExtractor {
 
 case class WiktionaryGenericText(text: String)
 case class WiktionaryTemplateInstance(name: String, arguments: String)
+case class WiktionaryTemplate(name: String, count: BigInt)

--- a/jobs/src/main/scala/com/foreignlanguagereader/jobs/definitions/TemplateExtractor.scala
+++ b/jobs/src/main/scala/com/foreignlanguagereader/jobs/definitions/TemplateExtractor.scala
@@ -42,6 +42,16 @@ object TemplateExtractor {
       .withColumnRenamed("element_at(col, 2)", "arguments")
       .sort("name")
       .as[WiktionaryTemplateInstance]
+  }
+
+  def extractTemplateCount(
+      data: Dataset[WiktionaryTemplateInstance]
+  )(implicit spark: SparkSession): Dataset[WiktionaryTemplate] = {
+    import spark.implicits._
+
+    data.groupBy("name").count().sort(col("count").desc).as[WiktionaryTemplate]
+  }
+
   val extractTemplatesFromString: String => Array[Array[String]] =
     (input: String) =>
       templateRegex.r

--- a/jobs/src/test/scala/TemplateExtractorTest.scala
+++ b/jobs/src/test/scala/TemplateExtractorTest.scala
@@ -1,0 +1,46 @@
+import com.foreignlanguagereader.jobs.definitions.{
+  TemplateExtractor,
+  WiktionaryGenericText
+}
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.{Dataset, SparkSession}
+import org.scalatest.funspec.AnyFunSpec
+
+class TemplateExtractorTest extends AnyFunSpec {
+  implicit val spark: SparkSession = {
+    SparkSession
+      .builder()
+      .master("local")
+      .appName("TemplateExtractorTest")
+      .getOrCreate()
+  }
+  import spark.implicits._
+
+  val text: String =
+    """===Pronunciation===
+      |* {{a|RP}} {{IPA|en|/ˈdɪkʃ(ə)n(ə)ɹi/}}
+      |* {{a|GenAm|Canada}} {{enPR|dĭk'shə-nĕr-ē}}, {{IPA|en|/ˈdɪkʃəˌnɛɹi/}}
+      |* {{audio|en|en-us-dictionary.ogg|Audio (US, California)}}
+      |* {{audio|en|en-uk-dictionary.ogg|Audio (UK)}}
+      |* {{hyphenation|en|dic|tion|ary}}
+      |* {{rhymes|en|ɪkʃənɛəɹi}}""".stripMargin
+
+  val entryraw: WiktionaryGenericText = WiktionaryGenericText(text)
+  val data: Dataset[WiktionaryGenericText] = Seq(entryraw).toDS()
+
+  describe("it can extract templates from an entry") {
+    it("can get all instances of templates with their arguments") {
+      val instances =
+        TemplateExtractor.extractTemplateInstances(data).cache()
+      assert(instances.count() == 9L)
+    }
+
+    it("can count how many times a template was used") {
+      val instances = TemplateExtractor.extractTemplateInstances(data)
+      val counts = TemplateExtractor.extractTemplateCount(instances).cache()
+
+      assert(counts.count() == 6L)
+      assert(counts.filter(col("count") > 1).count() == 3L)
+    }
+  }
+}


### PR DESCRIPTION
Extract all template examples from simple english wiktionary. This tells us which templates are most common, so we know what to implement first.