### PR TITLE
Whitelist cors for gatsby

### DIFF
--- a/api/conf/application.conf
+++ b/api/conf/application.conf
@@ -13,7 +13,7 @@ play.http.errorHandler = com.foreignlanguagereader.api.error.ErrorHandler
 
 play.filters.enabled += play.filters.cors.CORSFilter
 play.filters.cors {
-  allowedOrigins = ["https://www.foreignlanguagereader.com", "http://localhost:3000"]
+  allowedOrigins = ["https://www.foreignlanguagereader.com", "http://localhost:3000", "http://localhost:8000"]
   allowedHttpMethods = ["GET", "POST"]
 }
 

--- a/api/conf/production.conf
+++ b/api/conf/production.conf
@@ -8,7 +8,7 @@ play.http.errorHandler=com.foreignlanguagereader.api.error.ErrorHandler
 
 play.filters.enabled += play.filters.cors.CORSFilter
 play.filters.cors {
-  allowedOrigins = ["https://www.foreignlanguagereader.com", "http://localhost:3000"]
+  allowedOrigins = ["https://www.foreignlanguagereader.com", "http://localhost:3000", "http://localhost:8000"]
   allowedHttpMethods = ["GET", "POST"]
 }
 


### PR DESCRIPTION
Gatsby runs on a different port, so we need to allow cors for that port during development.