### PR TITLE
Section finder job hardening

### DIFF
--- a/jobs/src/main/scala/com/foreignlanguagereader/jobs/definitions/DatasetDefinitions.scala
+++ b/jobs/src/main/scala/com/foreignlanguagereader/jobs/definitions/DatasetDefinitions.scala
@@ -1,0 +1,13 @@
+package com.foreignlanguagereader.jobs.definitions
+
+/*
+ * Spark jobs can be typed, here are type definitions for all the intermediate stages
+ */
+
+// Common
+case class WiktionaryRawEntry(id: Long, token: String, text: String)
+case class WiktionaryRawText(text: String)
+
+// Template job specific
+case class WiktionaryTemplateInstance(name: String, arguments: String)
+case class WiktionaryTemplate(name: String, count: BigInt)

--- a/jobs/src/main/scala/com/foreignlanguagereader/jobs/definitions/Wiktionary.scala
+++ b/jobs/src/main/scala/com/foreignlanguagereader/jobs/definitions/Wiktionary.scala
@@ -53,6 +53,9 @@ object Wiktionary {
     metaArticleTitles.forall(prefix => !title.startsWith(prefix))
   }
 
+  // String.repeat is only implemented on some JVMs
+  // Removing this has burned me twice.
+  // Run the unit tests in the docker container before trying to remove it again.
   def repeat(token: String, count: Int): String = {
     (0 to count).map(_ => token).mkString
   }
@@ -117,7 +120,7 @@ object Wiktionary {
   }
 
   def getHeadingFromLine(line: String, equalsCount: Int): String = {
-    Try(line.replaceAll("=".repeat(equalsCount), "").trim.toLowerCase) match {
+    Try(line.replaceAll(repeat("=", equalsCount), "").trim.toLowerCase) match {
       case Success(heading) => heading
       case Failure(e) =>
         log.error(s"Failed to parse line $line", e)

--- a/jobs/src/main/scala/com/foreignlanguagereader/jobs/definitions/Wiktionary.scala
+++ b/jobs/src/main/scala/com/foreignlanguagereader/jobs/definitions/Wiktionary.scala
@@ -57,7 +57,7 @@ object Wiktionary {
   // Removing this has burned me twice.
   // Run the unit tests in the docker container before trying to remove it again.
   def repeat(token: String, count: Int): String = {
-    (0 to count).map(_ => token).mkString
+    (0 until count).map(_ => token).mkString
   }
 
   val caseInsensitiveFlag = "(?i)"

--- a/jobs/src/main/scala/com/foreignlanguagereader/jobs/definitions/Wiktionary.scala
+++ b/jobs/src/main/scala/com/foreignlanguagereader/jobs/definitions/Wiktionary.scala
@@ -55,10 +55,6 @@ object Wiktionary {
     metaArticleTitles.forall(prefix => !title.startsWith(prefix))
   }
 
-  def repeat(token: String, count: Int): String = {
-    (0 to count).map(_ => token).mkString
-  }
-
   val caseInsensitiveFlag = "(?i)"
   val periodMatchesNewlineFlag = "(?s)"
   val oneOrMoreEqualsSign = "=+"
@@ -72,13 +68,12 @@ object Wiktionary {
   val nextSectionOrEndOfFile = s"(?>$nextSection|\\Z)+"
 
   def headingRegex(equalsCount: Int): String =
-    repeat(
-      "=",
+    "=".repeat(
       equalsCount
-    ) + optionalWhiteSpace + anythingButEqualsSign + optionalWhiteSpace + repeat(
-      "=",
-      equalsCount
-    ) + anythingButEqualsSign // Needed or else outer equals will be ignored
+    ) + optionalWhiteSpace + anythingButEqualsSign + optionalWhiteSpace + "="
+      .repeat(
+        equalsCount
+      ) + anythingButEqualsSign // Needed or else outer equals will be ignored
   // Subtle but '== Test ==' will match '=== Test ===' at this point: '="== Test =="='
 
   def sectionRegex(sectionName: String): String =

--- a/jobs/src/main/scala/com/foreignlanguagereader/jobs/definitions/Wiktionary.scala
+++ b/jobs/src/main/scala/com/foreignlanguagereader/jobs/definitions/Wiktionary.scala
@@ -53,6 +53,10 @@ object Wiktionary {
     metaArticleTitles.forall(prefix => !title.startsWith(prefix))
   }
 
+  def repeat(token: String, count: Int): String = {
+    (0 to count).map(_ => token).mkString
+  }
+
   val caseInsensitiveFlag = "(?i)"
   val periodMatchesNewlineFlag = "(?s)"
   val oneOrMoreEqualsSign = "=+"
@@ -66,12 +70,13 @@ object Wiktionary {
   val nextSectionOrEndOfFile = s"(?>$nextSection|\\Z)+"
 
   def headingRegex(equalsCount: Int): String =
-    "=".repeat(
+    repeat(
+      "=",
       equalsCount
-    ) + optionalWhiteSpace + anythingButEqualsSign + optionalWhiteSpace + "="
-      .repeat(
-        equalsCount
-      ) + anythingButEqualsSign // Needed or else outer equals will be ignored
+    ) + optionalWhiteSpace + anythingButEqualsSign + optionalWhiteSpace + repeat(
+      "=",
+      equalsCount
+    ) + anythingButEqualsSign // Needed or else outer equals will be ignored
   // Subtle but '== Test ==' will match '=== Test ===' at this point: '="== Test =="='
 
   def sectionRegex(sectionName: String): String =

--- a/jobs/src/main/scala/com/foreignlanguagereader/jobs/definitions/exploration/SectionFinder.scala
+++ b/jobs/src/main/scala/com/foreignlanguagereader/jobs/definitions/exploration/SectionFinder.scala
@@ -10,7 +10,7 @@ import scala.util.{Failure, Success, Try}
 object SectionFinder {
   val jobName = "Wiktionary Section Extractor"
   val backupsBasePath =
-    "s3a://foreign-language-reader-content/definitions/wiktionary/"
+    "s3a://foreign-language-reader-content/definitions/wiktionary"
 
   val backups = Map(
     "chinese" -> "zhwiktionary-20210201-pages-meta-current.xml",
@@ -32,7 +32,7 @@ object SectionFinder {
       case (dictionary, path) =>
         findSectionsFromBackup(
           s"$backupsBasePath/$path",
-          s"$backupsBasePath/sections/$dictionary"
+          s"$backupsBasePath/sections/$dictionary.csv"
         )
     }.sum
 

--- a/jobs/src/main/scala/com/foreignlanguagereader/jobs/definitions/exploration/TemplateExtractor.scala
+++ b/jobs/src/main/scala/com/foreignlanguagereader/jobs/definitions/exploration/TemplateExtractor.scala
@@ -1,6 +1,11 @@
 package com.foreignlanguagereader.jobs.definitions.exploration
 
 import com.databricks.spark.xml._
+import com.foreignlanguagereader.jobs.definitions.{
+  WiktionaryRawText,
+  WiktionaryTemplate,
+  WiktionaryTemplateInstance
+}
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions.{col, element_at, posexplode, udf}
 import org.apache.spark.sql.{Dataset, SparkSession}
@@ -54,7 +59,7 @@ object TemplateExtractor {
 
   def loadWiktionaryDump(
       path: String
-  )(implicit spark: SparkSession): Dataset[WiktionaryGenericText] = {
+  )(implicit spark: SparkSession): Dataset[WiktionaryRawText] = {
     import spark.implicits._
 
     spark.read
@@ -62,11 +67,11 @@ object TemplateExtractor {
       .xml(path)
       .select("revision.text._VALUE")
       .withColumnRenamed("_VALUE", "text")
-      .as[WiktionaryGenericText]
+      .as[WiktionaryRawText]
   }
 
   def extractTemplateInstances(
-      data: Dataset[WiktionaryGenericText]
+      data: Dataset[WiktionaryRawText]
   )(implicit spark: SparkSession): Dataset[WiktionaryTemplateInstance] = {
     import spark.implicits._
 
@@ -111,7 +116,3 @@ object TemplateExtractor {
     extractTemplatesFromString
   )
 }
-
-case class WiktionaryGenericText(text: String)
-case class WiktionaryTemplateInstance(name: String, arguments: String)
-case class WiktionaryTemplate(name: String, count: BigInt)

--- a/jobs/src/test/scala/com/foreignlanguagereader/jobs/definitions/WiktionaryTest.scala
+++ b/jobs/src/test/scala/com/foreignlanguagereader/jobs/definitions/WiktionaryTest.scala
@@ -42,6 +42,7 @@ class WiktionaryTest extends AnyFunSpec {
       )
     }
   }
+
   describe("can get headings") {
     describe("for a single line") {
       it("on the happy path") {
@@ -50,6 +51,35 @@ class WiktionaryTest extends AnyFunSpec {
       }
       it("without error if there is no heading") {
         assert(Wiktionary.getHeadingFromLine("", 2) == "")
+      }
+      it("and returns error if there is bad input") {
+        assert(Wiktionary.getHeadingFromLine(null, 2) == "ERROR")
+      }
+    }
+
+    describe("for a document") {
+      it("on the happy path") {
+        val text =
+          """== This is a heading ==
+            |another document item
+            |=== subheading that should be ignored ===
+            |another garbage thing
+            |== This is another heading ==
+            |= heading level that doesn't exist =
+            |== uneven heading ===
+            |=== uneven in a different way ==
+            |""".stripMargin
+        assert(
+          Wiktionary.getHeadingsFromDocument(text, 2) sameElements Array(
+            "this is a heading",
+            "this is another heading"
+          )
+        )
+      }
+      it("and correctly handles bad input") {
+        assert(
+          Wiktionary.getHeadingsFromDocument(null, 2).isEmpty
+        )
       }
     }
   }

--- a/jobs/src/test/scala/com/foreignlanguagereader/jobs/definitions/WiktionaryTest.scala
+++ b/jobs/src/test/scala/com/foreignlanguagereader/jobs/definitions/WiktionaryTest.scala
@@ -3,44 +3,53 @@ package com.foreignlanguagereader.jobs.definitions
 import org.scalatest.funspec.AnyFunSpec
 
 class WiktionaryTest extends AnyFunSpec {
-  describe("a wiktionary test") {
-    describe("can correctly generate regexes") {
-      it("can repeat a pattern") {
-        assert(Wiktionary.repeat("=", 6) == "======")
+  describe("can correctly generate regexes") {
+    it("can repeat a pattern") {
+      assert(Wiktionary.repeat("=", 6) == "======")
+    }
+
+    describe("for a heading of any size") {
+      val levelThreeHeading = Wiktionary.headingRegex(3)
+      it("which match valid headings") {
+        assert("=== Title ===".matches(levelThreeHeading))
       }
 
-      describe("for a heading of any size") {
-        val levelThreeHeading = Wiktionary.headingRegex(3)
-        it("which match valid headings") {
-          assert("=== Title ===".matches(levelThreeHeading))
-        }
+      // There's some subtle bugs around matching too many and too few
+      // This is to prevent regression
 
-        // There's some subtle bugs around matching too many and too few
-        // This is to prevent regression
-
-        it("does not match larger headings") {
-          assert(!"== Title ==".matches(levelThreeHeading))
-        }
-
-        it("does not match smaller headings") {
-          assert(!"==== Title ====".matches(levelThreeHeading))
-        }
+      it("does not match larger headings") {
+        assert(!"== Title ==".matches(levelThreeHeading))
       }
 
-      // This is there to cover refactors, feel free to wipe the assertion if the regex materially changes.
-      it("for a section") {
-        assert(
-          "(?s)(?i)== *MyTestSection *==(.*?)(?>(?>== *[A-Za-z0-9]+ *==[ |\n]+)|\\Z)+" == Wiktionary
-            .sectionRegex("MyTestSection")
-        )
+      it("does not match smaller headings") {
+        assert(!"==== Title ====".matches(levelThreeHeading))
       }
+    }
 
-      // This is there to cover refactors, feel free to wipe the assertion if the regex materially changes.
-      it("for a subsection") {
-        assert(
-          "(?s)(?i)=== *MyTestSubsection *===(.*?)(?>(?>== *[A-Za-z0-9]+ *==[ |\n]+)|\\Z)+" == Wiktionary
-            .subSectionRegex("MyTestSubsection")
-        )
+    // This is there to cover refactors, feel free to wipe the assertion if the regex materially changes.
+    it("for a section") {
+      assert(
+        "(?s)(?i)== *MyTestSection *==(.*?)(?>(?>== *[A-Za-z0-9]+ *==[ |\n]+)|\\Z)+" == Wiktionary
+          .sectionRegex("MyTestSection")
+      )
+    }
+
+    // This is there to cover refactors, feel free to wipe the assertion if the regex materially changes.
+    it("for a subsection") {
+      assert(
+        "(?s)(?i)=== *MyTestSubsection *===(.*?)(?>(?>== *[A-Za-z0-9]+ *==[ |\n]+)|\\Z)+" == Wiktionary
+          .subSectionRegex("MyTestSubsection")
+      )
+    }
+  }
+  describe("can get headings") {
+    describe("for a single line") {
+      it("on the happy path") {
+        val test = "== Single heading =="
+        assert(Wiktionary.getHeadingFromLine(test, 2) == "single heading")
+      }
+      it("without error if there is no heading") {
+        assert(Wiktionary.getHeadingFromLine("", 2) == "")
       }
     }
   }

--- a/jobs/src/test/scala/com/foreignlanguagereader/jobs/definitions/WiktionaryTest.scala
+++ b/jobs/src/test/scala/com/foreignlanguagereader/jobs/definitions/WiktionaryTest.scala
@@ -1,0 +1,28 @@
+package com.foreignlanguagereader.jobs.definitions
+
+import org.scalatest.funspec.AnyFunSpec
+
+class WiktionaryTest extends AnyFunSpec {
+  describe("a wiktionary test") {
+    describe("can correctly generate regexes") {
+      it("can repeat a pattern") {
+        assert(Wiktionary.repeat("=", 6) == "======")
+      }
+
+      describe("for a heading of any size") {
+        val levelThreeHeading = Wiktionary.headingRegex(3)
+        it("which match valid headings") {
+          assert("=== Title ===".matches(levelThreeHeading))
+        }
+
+        it("does not match larger headings") {
+          assert(!"== Title ==".matches(levelThreeHeading))
+        }
+
+        it("does not match smaller headings") {
+          assert(!"==== Title ====".matches(levelThreeHeading))
+        }
+      }
+    }
+  }
+}

--- a/jobs/src/test/scala/com/foreignlanguagereader/jobs/definitions/WiktionaryTest.scala
+++ b/jobs/src/test/scala/com/foreignlanguagereader/jobs/definitions/WiktionaryTest.scala
@@ -15,6 +15,9 @@ class WiktionaryTest extends AnyFunSpec {
           assert("=== Title ===".matches(levelThreeHeading))
         }
 
+        // There's some subtle bugs around matching too many and too few
+        // This is to prevent regression
+
         it("does not match larger headings") {
           assert(!"== Title ==".matches(levelThreeHeading))
         }
@@ -22,6 +25,22 @@ class WiktionaryTest extends AnyFunSpec {
         it("does not match smaller headings") {
           assert(!"==== Title ====".matches(levelThreeHeading))
         }
+      }
+
+      // This is there to cover refactors, feel free to wipe the assertion if the regex materially changes.
+      it("for a section") {
+        assert(
+          "(?s)(?i)== *MyTestSection *==(.*?)(?>(?>== *[A-Za-z0-9]+ *==[ |\n]+)|\\Z)+" == Wiktionary
+            .sectionRegex("MyTestSection")
+        )
+      }
+
+      // This is there to cover refactors, feel free to wipe the assertion if the regex materially changes.
+      it("for a subsection") {
+        assert(
+          "(?s)(?i)=== *MyTestSubsection *===(.*?)(?>(?>== *[A-Za-z0-9]+ *==[ |\n]+)|\\Z)+" == Wiktionary
+            .subSectionRegex("MyTestSubsection")
+        )
       }
     }
   }

--- a/jobs/src/test/scala/com/foreignlanguagereader/jobs/definitions/WiktionaryTest.scala
+++ b/jobs/src/test/scala/com/foreignlanguagereader/jobs/definitions/WiktionaryTest.scala
@@ -53,7 +53,9 @@ class WiktionaryTest extends AnyFunSpec {
         assert(Wiktionary.getHeadingFromLine("", 2) == "")
       }
       it("and returns error if there is bad input") {
-        assert(Wiktionary.getHeadingFromLine(null, 2) == "ERROR")
+        assert(
+          Wiktionary.getHeadingFromLine(null, 2) == "ERROR" // scalastyle:ignore
+        )
       }
     }
 
@@ -78,7 +80,9 @@ class WiktionaryTest extends AnyFunSpec {
       }
       it("and correctly handles bad input") {
         assert(
-          Wiktionary.getHeadingsFromDocument(null, 2).isEmpty
+          Wiktionary
+            .getHeadingsFromDocument(null, 2) // scalastyle:ignore
+            .isEmpty
         )
       }
     }

--- a/jobs/src/test/scala/com/foreignlanguagereader/jobs/definitions/exploration/TemplateExtractorTest.scala
+++ b/jobs/src/test/scala/com/foreignlanguagereader/jobs/definitions/exploration/TemplateExtractorTest.scala
@@ -1,5 +1,6 @@
 package com.foreignlanguagereader.jobs.definitions.exploration
 
+import com.foreignlanguagereader.jobs.definitions.WiktionaryRawText
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.{Dataset, SparkSession}
 import org.scalatest.funspec.AnyFunSpec
@@ -26,8 +27,8 @@ class TemplateExtractorTest extends AnyFunSpec {
   val textWithNoArgumentsTemplate: String = text + "\n* {{test}}"
   val emptyText = ""
 
-  def getDatasetFromText(input: String): Dataset[WiktionaryGenericText] =
-    Seq(WiktionaryGenericText(input)).toDS()
+  def getDatasetFromText(input: String): Dataset[WiktionaryRawText] =
+    Seq(WiktionaryRawText(input)).toDS()
 
   describe("it can extract templates with arguments from an entry") {
     val data = getDatasetFromText(text)


### PR DESCRIPTION
These jobs fail on any one single error. That is not what we want. This hardens the jobs so that they log errors and continue.